### PR TITLE
Allow enabling recv timeout caching on mocksock

### DIFF
--- a/unit/include_public/avsystem/commons/unit/mocksock.h
+++ b/unit/include_public/avsystem/commons/unit/mocksock.h
@@ -147,6 +147,11 @@ void avs_unit_mocksock_assert_expects_met__(avs_net_abstract_socket_t *socket,
 #define avs_unit_mocksock_assert_expects_met(Socket) \
     avs_unit_mocksock_assert_expects_met__((Socket), __FILE__, __LINE__);
 
+
+void avs_unit_mocksock_enable_recv_timeout_getsetopt(
+        avs_net_abstract_socket_t *socket_,
+        int default_timeout_ms);
+
 #ifdef  __cplusplus
 }
 #endif


### PR DESCRIPTION
Summary:
I find it insane to constantly have to add all these `expect_get_opt` calls in C tests even though they have nothing to do with actually tested content. This diff makes it possible to call `avs_unit_mocksock_enable_recv_timeout_getsetopt()` only once at the setup stage and the mocksock will automatically mock behavior of an actual socket.

I think this could slightly improve readability of all our tests and make it easier to write new ones in the future. Please look at this and tell me what do you think.

Test Plan: make check on client coap stream tests (WIP)

Reviewers: kfyatek, mkrawiec

Differential Revision: https://phabricator.avsystem.com/D2243