### PR TITLE
Enhance certificate info struct validity checks

### DIFF
--- a/net/include_public/avsystem/commons/net.h
+++ b/net/include_public/avsystem/commons/net.h
@@ -336,6 +336,7 @@ avs_net_private_key_t avs_net_private_key_from_memory(avs_net_key_type_t type,
  * Certificate and key information may be read from files or passed as raw data.
  *
  * Setting both filename and data pointer for client_key/client_cert is invalid.
+ * When the ca_cert_raw.cert_der is not NULL, its size must not be zero.
  *
  * ca_cert_raw may be used with ca_cert_file/ca_cert_path to add an extra CA
  * certificate to the certificate store,

--- a/net/src/mbedtls.c
+++ b/net/src/mbedtls.c
@@ -946,6 +946,13 @@ static int configure_ssl_certs(ssl_socket_certs_t *certs,
                                const avs_net_certificate_info_t *cert_info) {
     LOG(TRACE, "configure_ssl_certs");
 
+    if (cert_info->ca_cert_raw.cert_der
+            && cert_info->ca_cert_raw.cert_size == 0) {
+        LOG(ERROR, "invalid certificate info: non-NULL raw certificate of size "
+            "0 given");
+        return -1;
+    }
+
     if (server_auth_enabled(cert_info)) {
         if (load_ca_certs(&certs->ca_cert,
                           cert_info->ca_cert_path,

--- a/net/src/openssl.c
+++ b/net/src/openssl.c
@@ -910,6 +910,13 @@ static int configure_ssl_certs(ssl_socket_t *socket,
                                const avs_net_certificate_info_t *cert_info) {
     LOG(TRACE, "configure_ssl_certs");
 
+    if (cert_info->ca_cert_raw.cert_der
+            && cert_info->ca_cert_raw.cert_size == 0) {
+        LOG(ERROR, "invalid certificate info: non-NULL raw certificate of size "
+            "0 given");
+        return -1;
+    }
+
     if (server_auth_enabled(cert_info)) {
         socket->verification = 1;
         SSL_CTX_set_verify(socket->ctx, SSL_VERIFY_PEER, NULL);


### PR DESCRIPTION
When `cert_der` field is set to a non-NULL buffer, but its size is 0.
That forces avs_commons to enable CA cert authentication, but there is
no cert to verify it server against.