### PR TITLE
Remove hard dependency on avs_log in avs_unit

### DIFF
--- a/config/config.h.in
+++ b/config/config.h.in
@@ -47,6 +47,7 @@
 #define WITH_SSL
 #endif
 
+#cmakedefine WITH_AVS_LOG
 #cmakedefine WITH_SOCKET_LOG
 
 #cmakedefine OPENSSL_CUSTOM_CIPHERS_ENABLED

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -19,7 +19,11 @@ set(PUBLIC_HEADERS
     include_public/avsystem/commons/unit/test.h)
 
 set(INCLUDE_DIRS include_public ../list/include_public ../log/include_public)
-set(DEPS_LIBRARIES avs_list avs_log)
+set(DEPS_LIBRARIES avs_list)
+
+if(WITH_AVS_LOG)
+    set(DEPS_LIBRARIES ${DEPS_LIBRARIES} avs_log)
+endif()
 
 if(WITH_AVS_NET)
     set(SOURCES ${SOURCES} src/mocksock.c)

--- a/unit/src/test.c
+++ b/unit/src/test.c
@@ -456,6 +456,7 @@ static void parse_command_line_args(int argc, char* argv[],
     }
 }
 
+#ifdef WITH_AVS_LOG
 static int parse_log_level(const char *str,
                            avs_log_level_t *level) {
     if (!strcasecmp(str, "trace")) {
@@ -543,6 +544,9 @@ static void process_env_vars(void) {
         atexit(avs_log_reset);
     }
 }
+#else /* WITH_AVS_LOG */
+static void process_env_vars(void) {}
+#endif /* WITH_AVS_LOG */
 
 int main(int argc, char *argv[]) {
     const char * volatile selected_suite = NULL;


### PR DESCRIPTION
Summary: Fixes C unit tests in libcwmp5, where avs_unit is used without avs_log.