### PR TITLE
Work around missing recvmsg() in LwIP

### DIFF
--- a/algorithm/src/test/base64.c
+++ b/algorithm/src/test/base64.c
@@ -192,7 +192,7 @@ AVS_UNIT_TEST(base64, encoded_and_decoded_size) {
     size_t i;
     size_t length;
     for (i = 0; i < sizeof(bytes); ++i) {
-        bytes[i] = (uint8_t) (rand() % 255);
+        bytes[i] = (uint8_t) (rand() % 256);
     }
     for (i = 0; i < sizeof(bytes); ++i) {
         AVS_UNIT_ASSERT_SUCCESS(avs_base64_encode(result, sizeof(result), bytes, i));

--- a/algorithm/src/test/base64.c
+++ b/algorithm/src/test/base64.c
@@ -192,7 +192,7 @@ AVS_UNIT_TEST(base64, encoded_and_decoded_size) {
     size_t i;
     size_t length;
     for (i = 0; i < sizeof(bytes); ++i) {
-        bytes[i] = (uint8_t) rand() % 255;
+        bytes[i] = (uint8_t) (rand() % 255);
     }
     for (i = 0; i < sizeof(bytes); ++i) {
         AVS_UNIT_ASSERT_SUCCESS(avs_base64_encode(result, sizeof(result), bytes, i));

--- a/net/include_public/avsystem/commons/net.h
+++ b/net/include_public/avsystem/commons/net.h
@@ -542,10 +542,63 @@ int avs_net_socket_send_to(avs_net_abstract_socket_t *socket,
                            size_t buffer_length,
                            const char *host,
                            const char *port);
+/**
+ * @param      socket             Socket object to read data from.
+ * @param[out] out_bytes_received Number of bytes successfully read into
+ *                                @p buffer after a call to this function.
+ * @param      buffer             Buffer to write read bytes to.
+ * @param      buffer_length      Number of bytes available in @p buffer .
+ *
+ * @returns 0 on success, a negative value in case of error. If an error
+ *          occurred, socket errno is set to indicate a specific error case.
+ *          See @ref avs_net_socket_errno .
+ *
+ * For UDP datagrams whose length exceeds @p buffer_length :
+ * - @p buffer is filled with @p buffer_length initial bytes of data,
+ * - @p buffer_length is returned via @p out_bytes_received ,
+ * - the function returns a negative value,
+ * - @p socket errno is set to EMSGSIZE. See @ref avs_net_socket_errno .
+ * That means, one can still access the truncated message if required. Note
+ * that the actual length of received datagram is lost.
+ *
+ * WARNING: When LwIP is used as a UDP/IP stack, this function MAY report the
+ * UDP datagram as truncated if it is exactly @p buffer_length bytes long.
+ */
 int avs_net_socket_receive(avs_net_abstract_socket_t *socket,
                            size_t *out_bytes_received,
                            void *buffer,
                            size_t buffer_length);
+
+/**
+ * @param      socket             Socket object to read data from.
+ * @param[out] out_bytes_received Number of bytes successfully read into
+ *                                @p buffer after a call to this function.
+ * @param      buffer             Buffer to write read bytes to.
+ * @param      buffer_length      Number of bytes available in @p buffer .
+ * @param[out] host               Buffer to store sender hostname. If possible,
+ *                                @p host is set to sender domain name,
+ *                                otherwise it is the sender IP address
+ *                                converted to a string.
+ * @param      host_size          Number of bytes available in @p host .
+ * @param[out] port               Buffer to store the port a message was sent
+ *                                from, converted to a string.
+ * @param      port_size          Number of bytes available in @p port .
+ *
+ * @returns 0 on success, a negative value in case of error. If an error
+ *          occurred, socket errno is set to indicate a specific error case.
+ *          See @ref avs_net_socket_errno .
+ *
+ * For UDP datagrams whose length exceeds @p buffer_length :
+ * - @p buffer is filled with @p buffer_length initial bytes of data,
+ * - @p buffer_length is returned via @p out_bytes_received ,
+ * - the function returns a negative value,
+ * - @p socket errno is set to EMSGSIZE. See @ref avs_net_socket_errno .
+ * That means, one can still access the truncated message if required. Note
+ * that the actual length of received datagram is lost.
+ *
+ * WARNING: When LwIP is used as a UDP/IP stack, this function MAY report the
+ * UDP datagram as truncated if it is exactly @p buffer_length bytes long.
+ */
 int avs_net_socket_receive_from(avs_net_abstract_socket_t *socket,
                                 size_t *out_bytes_received,
                                 void *buffer,

--- a/net/include_public/avsystem/commons/net.h
+++ b/net/include_public/avsystem/commons/net.h
@@ -561,7 +561,7 @@ int avs_net_socket_send_to(avs_net_abstract_socket_t *socket,
  * That means, one can still access the truncated message if required. Note
  * that the actual length of received datagram is lost.
  *
- * WARNING: When LwIP is used as a UDP/IP stack, this function MAY report the
+ * WARNING: When LwIP is used as a UDP/IP stack, this function will report the
  * UDP datagram as truncated if it is exactly @p buffer_length bytes long.
  */
 int avs_net_socket_receive(avs_net_abstract_socket_t *socket,
@@ -573,7 +573,7 @@ int avs_net_socket_receive(avs_net_abstract_socket_t *socket,
  * @param      socket             Socket object to read data from.
  * @param[out] out_bytes_received Number of bytes successfully read into
  *                                @p buffer after a call to this function.
- * @param      buffer             Buffer to write read bytes to.
+ * @param      buffer             Buffer to write received bytes to.
  * @param      buffer_length      Number of bytes available in @p buffer .
  * @param[out] host               Buffer to store sender hostname. If possible,
  *                                @p host is set to sender domain name,
@@ -596,7 +596,7 @@ int avs_net_socket_receive(avs_net_abstract_socket_t *socket,
  * That means, one can still access the truncated message if required. Note
  * that the actual length of received datagram is lost.
  *
- * WARNING: When LwIP is used as a UDP/IP stack, this function MAY report the
+ * WARNING: When LwIP is used as a UDP/IP stack, this function will report the
  * UDP datagram as truncated if it is exactly @p buffer_length bytes long.
  */
 int avs_net_socket_receive_from(avs_net_abstract_socket_t *socket,

--- a/net/src/net.c
+++ b/net/src/net.c
@@ -765,6 +765,8 @@ static ssize_t recvfrom_impl(avs_net_socket_t *net_socket,
     if (msg.msg_flags & MSG_TRUNC) {
         /* message too long to fit in the buffer */
         errno = EMSGSIZE;
+        recv_out = ((size_t)recv_out <= buffer_length) ? recv_out
+                                                       : (ssize_t)buffer_length;
     }
 
     if (addrlen) {


### PR DESCRIPTION
LwIP (1.4.1) does not implement recvmsg().