### PR TITLE
Do not pass MBEDTLS_VERSION_* as REQUIRED_VARS

### DIFF
--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -111,9 +111,6 @@ find_package_handle_standard_args(mbedTLS
                                       MBEDTLS_X509_LIBRARY
                                       MBEDTLS_LIBRARIES
                                       MBEDTLS_VERSION
-                                      MBEDTLS_VERSION_MAJOR
-                                      MBEDTLS_VERSION_MINOR
-                                      MBEDTLS_VERSION_PATCH
                                   VERSION_VAR MBEDTLS_VERSION)
 
 


### PR DESCRIPTION
find_package_handle_standard_args checks that all passed REQUIRED_VARS
are set to a "truthy" value. In cases where one of MBEDTLS_VERSION_*
variables has a value of 0, that made the whole find script fail.