### PR TITLE
Fix TRACE logs in avs_coap/avs_http

### DIFF
--- a/coap/src/coap_log.h
+++ b/coap/src/coap_log.h
@@ -17,8 +17,6 @@
 #ifndef AVS_COAP_LOG_H
 #define AVS_COAP_LOG_H
 
-#include <avsystem/commons/log.h>
-
 #define MODULE_NAME avs_coap
 #include <x_log_config.h>
 

--- a/http/src/http_log.h
+++ b/http/src/http_log.h
@@ -17,8 +17,6 @@
 #ifndef AVS_COMMONS_HTTP_LOG_H
 #define AVS_COMMONS_HTTP_LOG_H
 
-#include <avsystem/commons/log.h>
-
 #define MODULE_NAME avs_http
 #include <x_log_config.h>
 


### PR DESCRIPTION
`avsystem/commons/log.h` was included before `x_log_config.h` defined
`AVS_LOG_WITH_TRACE` macro, effectively making TRACE-logs from
`avs_coap`/`avs_http` always off, regardless of `WITH_INTERNAL_TRACE`
CMake flag.