### PR TITLE
Include <mbedtls/platform.h> in mbedtls.c

### DIFF
--- a/net/src/mbedtls.c
+++ b/net/src/mbedtls.c
@@ -24,6 +24,7 @@
 #define inline
 #endif
 
+#include <mbedtls/platform.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/net.h>


### PR DESCRIPTION
Not including it causes mbedtls_time_t to not be defined in mbedtls.c
for some toolchains (e.g. `arm-none-eabi-gcc`). We used to work around
that by explicit `-Dmbedtls_time_t=time_t` in compiler command line.
This approach seems to be a bit more elegant.