### PR TITLE
Avoid UB in overflow check

### DIFF
--- a/coap/src/opt.c
+++ b/coap/src/opt.c
@@ -192,7 +192,7 @@ bool avs_coap_opt_is_valid(const avs_coap_opt_t *opt, size_t max_opt_bytes) {
     }
 
     uint32_t length = (uint32_t)avs_coap_opt_sizeof(opt);
-    return opt->content + length >= opt->content
+    return (uintptr_t) opt->content + length >= (uintptr_t) opt->content
             && length <= max_opt_bytes;
 }
 


### PR DESCRIPTION
Summary:
Issue found by cppcheck:
[avs_commons/git/coap/src/opt.c:195]: (warning) Invalid test for
overflow 'opt.content+length>=opt.content'. Condition is always true
unless there is overflow, and overflow is UB.

Test Plan:
Verified by manual comparison of generated assembly with `-O2 -g`.

Before this diff:

```
>>> disas /s avs_coap_opt_is_valid
[...]
194         uint32_t length = (uint32_t)avs_coap_opt_sizeof(opt);
   0x00000000004111af <+63>:    mov    rdi,rbp
   0x00000000004111b2 <+66>:    call   0x411140 <avs_coap_opt_sizeof>

195         return opt->content + length >= opt->content
   0x00000000004111b7 <+71>:    mov    eax,eax
   0x00000000004111b9 <+73>:    cmp    rbx,rax
   0x00000000004111bc <+76>:    setae  al
   0x00000000004111bf <+79>:    jmp    0x411197 <avs_coap_opt_is_valid+39>
End of assembler dump.
```

After this diff:

```
>>> disas /s avs_coap_opt_is_valid
[...]
194         uint32_t length = (uint32_t)avs_coap_opt_sizeof(opt);
   0x00000000004111af <+63>:    mov    rdi,rbx
   0x00000000004111b2 <+66>:    call   0x411140 <avs_coap_opt_sizeof>

195         return (uintptr_t) opt->content + length >= (uintptr_t) opt->content
   0x00000000004111b7 <+71>:    lea    rdi,[rbx+0x1]
   0x00000000004111bb <+75>:    mov    edx,eax

196                 && length <= max_opt_bytes;
   0x00000000004111bd <+77>:    add    rdi,rdx
   0x00000000004111c0 <+80>:    setae  cl
   0x00000000004111c3 <+83>:    cmp    rbp,rdx
   0x00000000004111c6 <+86>:    setae  al
   0x00000000004111c9 <+89>:    and    eax,ecx

195         return (uintptr_t) opt->content + length >= (uintptr_t) opt->content
   0x00000000004111cb <+91>:    jmp    0x411197 <avs_coap_opt_is_valid+39>
End of assembler dump.
```

Reviewers: kfyatek!, mkrawiec!

Differential Revision: https://phabricator.avsystem.com/D6459