### PR TITLE
Fix endianness issue in CoAP decoding

### DIFF
--- a/coap/src/msg_info.c
+++ b/coap/src/msg_info.c
@@ -194,7 +194,7 @@ int avs_coap_msg_info_opt_uint(avs_coap_msg_info_t *info,
                                uint16_t opt_number,
                                const void *value,
                                size_t value_size) {
-#ifdef AVS_BIG_ENDIAN
+#ifdef AVS_COMMONS_BIG_ENDIAN
     const uint8_t *converted = (const uint8_t *) value;
 #else
     uint8_t converted[value_size];

--- a/coap/src/opt.c
+++ b/coap/src/opt.c
@@ -86,7 +86,7 @@ int avs_coap_opt_uint_value(const avs_coap_opt_t *opt,
         return -1;
     }
     memset(out_value, 0, out_value_size);
-#ifdef AVS_BIG_ENDIAN
+#ifdef AVS_COMMONS_BIG_ENDIAN
     memcpy(((char *) out_value) + (out_value_size - length), value, length);
 #else
     for (size_t i = 0; i < length; ++i) {


### PR DESCRIPTION
Endianness check macro is spelled AVS_COMMONS_BIG_ENDIAN, but CoAP
packet decoder used AVS_BIG_ENDIAN instead, which was never defined. It
accidentally worked on all platforms we tested previously, because all
of them happened to be little-endian.