### PR TITLE
Make sure LWIP_VERSION_MAJOR is actually defined in net_impl.c

### DIFF
--- a/compat/lwip-posix-compat.h
+++ b/compat/lwip-posix-compat.h
@@ -30,6 +30,9 @@
 /* Provides htons/ntohs/htonl/ntohl */
 #include "lwip/inet.h"
 
+/* Provides e.g. LWIP_VERSION_* macros used in net_impl.c */
+#include "lwip/init.h"
+
 /*
  * Provides:
  * - POSIX-compatible socket API, socklen_t,


### PR DESCRIPTION
This doesn't fix anything, but at least makes sure this code:
// LwIP < 2.0 lacks cast to unsigned inside FD_* macros

works as it should.