### PR TITLE
Add AVS_ASSERT and AVS_UNREACHABLE

### DIFF
--- a/coap/include_public/avsystem/commons/coap/msg_builder.h
+++ b/coap/include_public/avsystem/commons/coap/msg_builder.h
@@ -183,7 +183,7 @@ avs_coap_msg_build_without_payload(avs_coap_aligned_msg_buffer_t *buffer,
                                    const avs_coap_msg_info_t *info) {
     avs_coap_msg_builder_t builder;
     if (avs_coap_msg_builder_init(&builder, buffer, buffer_size, info)) {
-        AVS_ASSERT_FAIL("could not initialize msg builder");
+        AVS_UNREACHABLE("could not initialize msg builder");
         return NULL;
     }
 

--- a/coap/include_public/avsystem/commons/coap/msg_builder.h
+++ b/coap/include_public/avsystem/commons/coap/msg_builder.h
@@ -89,8 +89,8 @@ typedef struct avs_coap_aligned_msg_buffer avs_coap_aligned_msg_buffer_t;
  */
 static inline avs_coap_aligned_msg_buffer_t *
 avs_coap_ensure_aligned_buffer(void *buffer) {
-    assert((uintptr_t)buffer % AVS_ALIGNOF(avs_coap_msg_t) == 0
-           && "the buffer MUST have the same alignment as avs_coap_msg_t");
+    AVS_ASSERT((uintptr_t)buffer % AVS_ALIGNOF(avs_coap_msg_t) == 0,
+               "the buffer MUST have the same alignment as avs_coap_msg_t");
 
     return (avs_coap_aligned_msg_buffer_t *)buffer;
 }
@@ -183,7 +183,7 @@ avs_coap_msg_build_without_payload(avs_coap_aligned_msg_buffer_t *buffer,
                                    const avs_coap_msg_info_t *info) {
     avs_coap_msg_builder_t builder;
     if (avs_coap_msg_builder_init(&builder, buffer, buffer_size, info)) {
-        assert(0 && "could not initialize msg builder");
+        AVS_ASSERT(0, "could not initialize msg builder");
         return NULL;
     }
 

--- a/coap/include_public/avsystem/commons/coap/msg_builder.h
+++ b/coap/include_public/avsystem/commons/coap/msg_builder.h
@@ -183,7 +183,7 @@ avs_coap_msg_build_without_payload(avs_coap_aligned_msg_buffer_t *buffer,
                                    const avs_coap_msg_info_t *info) {
     avs_coap_msg_builder_t builder;
     if (avs_coap_msg_builder_init(&builder, buffer, buffer_size, info)) {
-        AVS_ASSERT(0, "could not initialize msg builder");
+        AVS_ASSERT_FAIL("could not initialize msg builder");
         return NULL;
     }
 

--- a/coap/src/block_builder.c
+++ b/coap/src/block_builder.c
@@ -101,8 +101,8 @@ avs_coap_block_builder_build(avs_coap_block_builder_t *builder,
                              size_t buffer_size) {
     assert(buffer_size
            >= avs_coap_msg_info_get_packet_storage_size(info, block_size));
-    assert(block_size < builder->payload_capacity
-           && "payload buffer MUST be able to hold more than a single block");
+    AVS_ASSERT(block_size < builder->payload_capacity,
+               "payload buffer MUST be able to hold more than a single block");
 
 
     if (builder->read_offset == builder->write_offset) {
@@ -112,7 +112,7 @@ avs_coap_block_builder_build(avs_coap_block_builder_t *builder,
 
     avs_coap_msg_builder_t msg_builder;
     if (avs_coap_msg_builder_init(&msg_builder, buffer, buffer_size, info)) {
-        assert(0 && "Failed to init msg_builder");
+        AVS_ASSERT(0, "Failed to init msg_builder");
         return NULL;
     }
 
@@ -132,7 +132,7 @@ avs_coap_block_builder_build(avs_coap_block_builder_t *builder,
             &msg_builder, payload_read_ptr(builder), bytes_to_write);
 
     if (bytes_to_write != bytes_written) {
-        assert(0 && "Could not flush the payload");
+        AVS_ASSERT(0, "Could not flush the payload");
         return NULL;
     }
 

--- a/coap/src/block_builder.c
+++ b/coap/src/block_builder.c
@@ -112,7 +112,7 @@ avs_coap_block_builder_build(avs_coap_block_builder_t *builder,
 
     avs_coap_msg_builder_t msg_builder;
     if (avs_coap_msg_builder_init(&msg_builder, buffer, buffer_size, info)) {
-        AVS_ASSERT(0, "Failed to init msg_builder");
+        AVS_ASSERT_FAIL("Failed to init msg_builder");
         return NULL;
     }
 
@@ -132,7 +132,7 @@ avs_coap_block_builder_build(avs_coap_block_builder_t *builder,
             &msg_builder, payload_read_ptr(builder), bytes_to_write);
 
     if (bytes_to_write != bytes_written) {
-        AVS_ASSERT(0, "Could not flush the payload");
+        AVS_ASSERT_FAIL("Could not flush the payload");
         return NULL;
     }
 

--- a/coap/src/block_builder.c
+++ b/coap/src/block_builder.c
@@ -112,7 +112,7 @@ avs_coap_block_builder_build(avs_coap_block_builder_t *builder,
 
     avs_coap_msg_builder_t msg_builder;
     if (avs_coap_msg_builder_init(&msg_builder, buffer, buffer_size, info)) {
-        AVS_ASSERT_FAIL("Failed to init msg_builder");
+        AVS_UNREACHABLE("Failed to init msg_builder");
         return NULL;
     }
 
@@ -132,7 +132,7 @@ avs_coap_block_builder_build(avs_coap_block_builder_t *builder,
             &msg_builder, payload_read_ptr(builder), bytes_to_write);
 
     if (bytes_to_write != bytes_written) {
-        AVS_ASSERT_FAIL("Could not flush the payload");
+        AVS_UNREACHABLE("Could not flush the payload");
         return NULL;
     }
 

--- a/coap/src/msg.c
+++ b/coap/src/msg.c
@@ -81,7 +81,7 @@ avs_coap_msg_code_to_string(uint8_t code, char *buf, size_t buf_size) {
                             avs_coap_msg_code_get_class(code),
                             avs_coap_msg_code_get_detail(code), name)
             < 0) {
-        assert(0 && "buffer too small for CoAP msg code string");
+        AVS_ASSERT(0, "buffer too small for CoAP msg code string");
         return "<error>";
     }
 
@@ -301,7 +301,7 @@ static void fill_block_summary(const avs_coap_msg_t *msg,
     if (avs_coap_msg_find_unique_opt(msg, block_opt_num, &opt)) {
         if (opt && avs_simple_snprintf(buf, buf_size,
                                        ", multiple BLOCK%d options", num) < 0) {
-           assert(0 && "should never happen");
+           AVS_ASSERT(0, "should never happen");
            *buf = '\0';
         }
         return;
@@ -315,7 +315,7 @@ static void fill_block_summary(const avs_coap_msg_t *msg,
             || avs_coap_opt_block_has_more(opt, &has_more)) {
         if (avs_simple_snprintf(buf, buf_size, ", BLOCK%d (bad content)", num)
                 < 0) {
-            assert(0 && "should never happen");
+            AVS_ASSERT(0, "should never happen");
             *buf = '\0';
         }
         return;
@@ -324,7 +324,7 @@ static void fill_block_summary(const avs_coap_msg_t *msg,
     if (avs_coap_opt_block_size(opt, &block_size)) {
         if (avs_simple_snprintf(buf, buf_size, ", BLOCK%d (bad size)", num)
                 < 0) {
-            assert(0 && "should never happen");
+            AVS_ASSERT(0, "should never happen");
             *buf = '\0';
         }
         return;
@@ -335,7 +335,7 @@ static void fill_block_summary(const avs_coap_msg_t *msg,
                             ", more %d)", num, seq_num, block_size,
                             (int) has_more)
             < 0) {
-        assert(0 && "should never happen");
+        AVS_ASSERT(0, "should never happen");
         *buf = '\0';
     }
 }
@@ -364,7 +364,7 @@ avs_coap_msg_summary(const avs_coap_msg_t *msg, char *buf, size_t buf_size) {
              avs_coap_msg_get_id(msg),
              token_string, (unsigned long)token.size,
              block1, block2) < 0) {
-        assert(0 && "should never happen");
+        AVS_ASSERT(0, "should never happen");
         return "(cannot create summary)";
     }
     return buf;

--- a/coap/src/msg.c
+++ b/coap/src/msg.c
@@ -81,7 +81,7 @@ avs_coap_msg_code_to_string(uint8_t code, char *buf, size_t buf_size) {
                             avs_coap_msg_code_get_class(code),
                             avs_coap_msg_code_get_detail(code), name)
             < 0) {
-        AVS_ASSERT_FAIL("buffer too small for CoAP msg code string");
+        AVS_UNREACHABLE("buffer too small for CoAP msg code string");
         return "<error>";
     }
 
@@ -301,7 +301,7 @@ static void fill_block_summary(const avs_coap_msg_t *msg,
     if (avs_coap_msg_find_unique_opt(msg, block_opt_num, &opt)) {
         if (opt && avs_simple_snprintf(buf, buf_size,
                                        ", multiple BLOCK%d options", num) < 0) {
-           AVS_ASSERT_FAIL("should never happen");
+           AVS_UNREACHABLE("should never happen");
            *buf = '\0';
         }
         return;
@@ -315,7 +315,7 @@ static void fill_block_summary(const avs_coap_msg_t *msg,
             || avs_coap_opt_block_has_more(opt, &has_more)) {
         if (avs_simple_snprintf(buf, buf_size, ", BLOCK%d (bad content)", num)
                 < 0) {
-            AVS_ASSERT_FAIL("should never happen");
+            AVS_UNREACHABLE("should never happen");
             *buf = '\0';
         }
         return;
@@ -324,7 +324,7 @@ static void fill_block_summary(const avs_coap_msg_t *msg,
     if (avs_coap_opt_block_size(opt, &block_size)) {
         if (avs_simple_snprintf(buf, buf_size, ", BLOCK%d (bad size)", num)
                 < 0) {
-            AVS_ASSERT_FAIL("should never happen");
+            AVS_UNREACHABLE("should never happen");
             *buf = '\0';
         }
         return;
@@ -335,7 +335,7 @@ static void fill_block_summary(const avs_coap_msg_t *msg,
                             ", more %d)", num, seq_num, block_size,
                             (int) has_more)
             < 0) {
-        AVS_ASSERT_FAIL("should never happen");
+        AVS_UNREACHABLE("should never happen");
         *buf = '\0';
     }
 }
@@ -364,7 +364,7 @@ avs_coap_msg_summary(const avs_coap_msg_t *msg, char *buf, size_t buf_size) {
              avs_coap_msg_get_id(msg),
              token_string, (unsigned long)token.size,
              block1, block2) < 0) {
-        AVS_ASSERT_FAIL("should never happen");
+        AVS_UNREACHABLE("should never happen");
         return "(cannot create summary)";
     }
     return buf;

--- a/coap/src/msg.c
+++ b/coap/src/msg.c
@@ -81,7 +81,7 @@ avs_coap_msg_code_to_string(uint8_t code, char *buf, size_t buf_size) {
                             avs_coap_msg_code_get_class(code),
                             avs_coap_msg_code_get_detail(code), name)
             < 0) {
-        AVS_ASSERT(0, "buffer too small for CoAP msg code string");
+        AVS_ASSERT_FAIL("buffer too small for CoAP msg code string");
         return "<error>";
     }
 
@@ -301,7 +301,7 @@ static void fill_block_summary(const avs_coap_msg_t *msg,
     if (avs_coap_msg_find_unique_opt(msg, block_opt_num, &opt)) {
         if (opt && avs_simple_snprintf(buf, buf_size,
                                        ", multiple BLOCK%d options", num) < 0) {
-           AVS_ASSERT(0, "should never happen");
+           AVS_ASSERT_FAIL("should never happen");
            *buf = '\0';
         }
         return;
@@ -315,7 +315,7 @@ static void fill_block_summary(const avs_coap_msg_t *msg,
             || avs_coap_opt_block_has_more(opt, &has_more)) {
         if (avs_simple_snprintf(buf, buf_size, ", BLOCK%d (bad content)", num)
                 < 0) {
-            AVS_ASSERT(0, "should never happen");
+            AVS_ASSERT_FAIL("should never happen");
             *buf = '\0';
         }
         return;
@@ -324,7 +324,7 @@ static void fill_block_summary(const avs_coap_msg_t *msg,
     if (avs_coap_opt_block_size(opt, &block_size)) {
         if (avs_simple_snprintf(buf, buf_size, ", BLOCK%d (bad size)", num)
                 < 0) {
-            AVS_ASSERT(0, "should never happen");
+            AVS_ASSERT_FAIL("should never happen");
             *buf = '\0';
         }
         return;
@@ -335,7 +335,7 @@ static void fill_block_summary(const avs_coap_msg_t *msg,
                             ", more %d)", num, seq_num, block_size,
                             (int) has_more)
             < 0) {
-        AVS_ASSERT(0, "should never happen");
+        AVS_ASSERT_FAIL("should never happen");
         *buf = '\0';
     }
 }
@@ -364,7 +364,7 @@ avs_coap_msg_summary(const avs_coap_msg_t *msg, char *buf, size_t buf_size) {
              avs_coap_msg_get_id(msg),
              token_string, (unsigned long)token.size,
              block1, block2) < 0) {
-        AVS_ASSERT(0, "should never happen");
+        AVS_ASSERT_FAIL("should never happen");
         return "(cannot create summary)";
     }
     return buf;

--- a/coap/src/msg_builder.c
+++ b/coap/src/msg_builder.c
@@ -220,8 +220,8 @@ avs_coap_msg_builder_payload_remaining(const avs_coap_msg_builder_t *builder) {
 size_t avs_coap_msg_builder_payload(avs_coap_msg_builder_t *builder,
                                     const void *payload,
                                     size_t payload_size) {
-    assert(avs_coap_msg_builder_is_initialized(builder)
-           && "avs_coap_msg_builder_payload called on uninitialized builder");
+    AVS_ASSERT(avs_coap_msg_builder_is_initialized(builder),
+               "avs_coap_msg_builder_payload called on uninitialized builder");
 
     if (payload_size == 0) {
         return 0;
@@ -236,13 +236,13 @@ size_t avs_coap_msg_builder_payload(avs_coap_msg_builder_t *builder,
     }
     if (!builder->has_payload_marker && bytes_to_write) {
         result = append_byte(&builder->msg_buffer, AVS_COAP_PAYLOAD_MARKER);
-        assert(!result && "attempted to write an invalid amount of bytes");
+        AVS_ASSERT(!result, "attempted to write an invalid amount of bytes");
 
         builder->has_payload_marker = true;
     }
 
     result = append_data(&builder->msg_buffer, payload, bytes_to_write);
-    assert(!result && "attempted to write an invalid amount of bytes");
+    AVS_ASSERT(!result, "attempted to write an invalid amount of bytes");
     (void)result;
 
     return bytes_to_write;

--- a/include_public/avsystem/commons/defs.h.in
+++ b/include_public/avsystem/commons/defs.h.in
@@ -19,6 +19,8 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
+#include <assert.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -308,5 +310,11 @@ struct AvsCallWithCast__ {
 #define AVS_MIN(a, b) ((a) < (b) ? (a) : (b))
 #define AVS_MAX(a, b) ((a) < (b) ? (b) : (a))
 #define AVS_ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+
+/*
+ * Definition of an assert with hard-coded string literal message that does not
+ * trigger compiler warnings.
+ */
+#define AVS_ASSERT(cond, msg) assert((cond) && (bool) "" msg)
 
 #endif	/* AVS_COMMONS_DEFS_H */

--- a/include_public/avsystem/commons/defs.h.in
+++ b/include_public/avsystem/commons/defs.h.in
@@ -316,5 +316,6 @@ struct AvsCallWithCast__ {
  * trigger compiler warnings.
  */
 #define AVS_ASSERT(cond, msg) assert((cond) && (bool) "" msg)
+#define AVS_ASSERT_FAIL(msg) AVS_ASSERT(0, msg)
 
 #endif	/* AVS_COMMONS_DEFS_H */

--- a/include_public/avsystem/commons/defs.h.in
+++ b/include_public/avsystem/commons/defs.h.in
@@ -316,6 +316,11 @@ struct AvsCallWithCast__ {
  * trigger compiler warnings.
  */
 #define AVS_ASSERT(cond, msg) assert((cond) && (bool) "" msg)
-#define AVS_ASSERT_FAIL(msg) AVS_ASSERT(0, msg)
+
+/*
+ * Marks an execution path as breaking some invariants, which should never
+ * happen in correct code.
+ */
+#define AVS_UNREACHABLE(msg) AVS_ASSERT(0, msg)
 
 #endif	/* AVS_COMMONS_DEFS_H */

--- a/list/src/list.c
+++ b/list/src/list.c
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-#ifdef NDEBUG
-#undef NDEBUG /* we want to call assert() in avs_list_assert_acyclic__() */
-#endif
-
 #include <avs_commons_config.h>
 
-#include <assert.h>
 #include <string.h>
 
-/* but we don't want avs_list_assert_acyclic__ called from our own internals */
+/* We don't want avs_list_assert_acyclic__ called from our own internals */
 #define NDEBUG
 #include <avsystem/commons/list.h>
+
+#ifdef NDEBUG
+# undef NDEBUG /* we want to call assert() in avs_list_assert_acyclic__() */
+#endif
+#include <assert.h>
 
 VISIBILITY_SOURCE_BEGIN
 
@@ -191,7 +191,6 @@ void *avs_list_simple_clone__(void *list, size_t elem_size) {
     return retval;
 }
 
-#ifndef NDEBUG
 static int is_list_sorted(void *list,
                           avs_list_comparator_func_t comparator,
                           size_t element_size) {
@@ -206,7 +205,6 @@ static int is_list_sorted(void *list,
     }
     return 1;
 }
-#endif // NDEBUG
 
 void **avs_list_assert_sorted_ptr__(void **listptr,
                                     avs_list_comparator_func_t comparator,

--- a/list/src/list.c
+++ b/list/src/list.c
@@ -23,7 +23,7 @@
 #include <avsystem/commons/list.h>
 
 #ifdef NDEBUG
-# undef NDEBUG /* we want to call assert() in avs_list_assert_acyclic__() */
+# undef NDEBUG /* We want to call assert() in avs_list_assert_acyclic__() */
 #endif
 #include <assert.h>
 

--- a/list/src/list.c
+++ b/list/src/list.c
@@ -191,9 +191,10 @@ void *avs_list_simple_clone__(void *list, size_t elem_size) {
     return retval;
 }
 
-static inline int is_list_sorted(void *list,
-                                 avs_list_comparator_func_t comparator,
-                                 size_t element_size) {
+#ifndef NDEBUG
+static int is_list_sorted(void *list,
+                          avs_list_comparator_func_t comparator,
+                          size_t element_size) {
     AVS_LIST(void) curr = list;
     AVS_LIST(void) next = list ? AVS_LIST_NEXT(list) : NULL;
     while (curr && next) {
@@ -205,6 +206,7 @@ static inline int is_list_sorted(void *list,
     }
     return 1;
 }
+#endif // NDEBUG
 
 void **avs_list_assert_sorted_ptr__(void **listptr,
                                     avs_list_comparator_func_t comparator,

--- a/list/src/list.c
+++ b/list/src/list.c
@@ -191,9 +191,9 @@ void *avs_list_simple_clone__(void *list, size_t elem_size) {
     return retval;
 }
 
-static int is_list_sorted(void *list,
-                          avs_list_comparator_func_t comparator,
-                          size_t element_size) {
+static inline int is_list_sorted(void *list,
+                                 avs_list_comparator_func_t comparator,
+                                 size_t element_size) {
     AVS_LIST(void) curr = list;
     AVS_LIST(void) next = list ? AVS_LIST_NEXT(list) : NULL;
     while (curr && next) {
@@ -209,6 +209,8 @@ static int is_list_sorted(void *list,
 void **avs_list_assert_sorted_ptr__(void **listptr,
                                     avs_list_comparator_func_t comparator,
                                     size_t element_size) {
+    (void) comparator;
+    (void) element_size;
     assert(is_list_sorted(*listptr, comparator, element_size));
     return listptr;
 }

--- a/net/compat/posix/net_impl.c
+++ b/net/compat/posix/net_impl.c
@@ -684,10 +684,12 @@ static int configure_socket(avs_net_socket_t *net_socket) {
     return 0;
 }
 
+#ifndef HAVE_POLL
 static inline bool is_valid_timeout(avs_time_duration_t timeout) {
     return avs_time_duration_valid(timeout)
             && !avs_time_duration_less(timeout, AVS_TIME_DURATION_ZERO);
 }
+#endif // !HAVE_POLL
 
 static short wait_until_ready(sockfd_t sockfd, avs_time_duration_t timeout,
                               char in, char out, char err) {

--- a/net/compat/posix/net_impl.c
+++ b/net/compat/posix/net_impl.c
@@ -950,7 +950,7 @@ static int get_requested_family(avs_net_socket_t *net_socket,
             return -1;
         }
     }
-    AVS_ASSERT(0, "Invalid value of preferred_family_mode");
+    AVS_ASSERT_FAIL("Invalid value of preferred_family_mode");
     return -1;
 }
 

--- a/net/compat/posix/net_impl.c
+++ b/net/compat/posix/net_impl.c
@@ -952,7 +952,7 @@ static int get_requested_family(avs_net_socket_t *net_socket,
             return -1;
         }
     }
-    AVS_ASSERT_FAIL("Invalid value of preferred_family_mode");
+    AVS_UNREACHABLE("Invalid value of preferred_family_mode");
     return -1;
 }
 

--- a/net/compat/posix/net_impl.c
+++ b/net/compat/posix/net_impl.c
@@ -950,7 +950,7 @@ static int get_requested_family(avs_net_socket_t *net_socket,
             return -1;
         }
     }
-    assert(0 && "Invalid value of preferred_family_mode");
+    AVS_ASSERT(0, "Invalid value of preferred_family_mode");
     return -1;
 }
 

--- a/net/src/mbedtls/data_loader.c
+++ b/net/src/mbedtls/data_loader.c
@@ -103,7 +103,7 @@ int _avs_net_mbedtls_load_ca_certs(mbedtls_x509_crt **out,
         return append_cert_from_buffer(*out, info->desc.info.buffer.buffer,
                                        info->desc.info.buffer.buffer_size);
     default:
-        AVS_ASSERT_FAIL("invalid data source");
+        AVS_UNREACHABLE("invalid data source");
         return -1;
     }
     return 0;
@@ -129,7 +129,7 @@ int _avs_net_mbedtls_load_client_cert(mbedtls_x509_crt **out,
         return append_cert_from_buffer(*out, info->desc.info.buffer.buffer,
                                        info->desc.info.buffer.buffer_size);
     default:
-        AVS_ASSERT_FAIL("invalid data source");
+        AVS_UNREACHABLE("invalid data source");
         return -1;
     }
     return 0;
@@ -183,7 +183,7 @@ int _avs_net_mbedtls_load_client_key(mbedtls_pk_context **client_key,
                                             info->desc.info.buffer.buffer_size,
                                             info->desc.info.buffer.password);
     default:
-        AVS_ASSERT_FAIL("invalid data source");
+        AVS_UNREACHABLE("invalid data source");
         return -1;
     }
     return 0;

--- a/net/src/mbedtls/data_loader.c
+++ b/net/src/mbedtls/data_loader.c
@@ -103,7 +103,7 @@ int _avs_net_mbedtls_load_ca_certs(mbedtls_x509_crt **out,
         return append_cert_from_buffer(*out, info->desc.info.buffer.buffer,
                                        info->desc.info.buffer.buffer_size);
     default:
-        AVS_ASSERT(0, "invalid data source");
+        AVS_ASSERT_FAIL("invalid data source");
         return -1;
     }
     return 0;
@@ -129,7 +129,7 @@ int _avs_net_mbedtls_load_client_cert(mbedtls_x509_crt **out,
         return append_cert_from_buffer(*out, info->desc.info.buffer.buffer,
                                        info->desc.info.buffer.buffer_size);
     default:
-        AVS_ASSERT(0, "invalid data source");
+        AVS_ASSERT_FAIL("invalid data source");
         return -1;
     }
     return 0;
@@ -183,7 +183,7 @@ int _avs_net_mbedtls_load_client_key(mbedtls_pk_context **client_key,
                                             info->desc.info.buffer.buffer_size,
                                             info->desc.info.buffer.password);
     default:
-        AVS_ASSERT(0, "invalid data source");
+        AVS_ASSERT_FAIL("invalid data source");
         return -1;
     }
     return 0;

--- a/net/src/mbedtls/data_loader.c
+++ b/net/src/mbedtls/data_loader.c
@@ -103,7 +103,7 @@ int _avs_net_mbedtls_load_ca_certs(mbedtls_x509_crt **out,
         return append_cert_from_buffer(*out, info->desc.info.buffer.buffer,
                                        info->desc.info.buffer.buffer_size);
     default:
-        assert(0 && "invalid data source");
+        AVS_ASSERT(0, "invalid data source");
         return -1;
     }
     return 0;
@@ -129,7 +129,7 @@ int _avs_net_mbedtls_load_client_cert(mbedtls_x509_crt **out,
         return append_cert_from_buffer(*out, info->desc.info.buffer.buffer,
                                        info->desc.info.buffer.buffer_size);
     default:
-        assert(0 && "invalid data source");
+        AVS_ASSERT(0, "invalid data source");
         return -1;
     }
     return 0;
@@ -183,7 +183,7 @@ int _avs_net_mbedtls_load_client_key(mbedtls_pk_context **client_key,
                                             info->desc.info.buffer.buffer_size,
                                             info->desc.info.buffer.password);
     default:
-        assert(0 && "invalid data source");
+        AVS_ASSERT(0, "invalid data source");
         return -1;
     }
     return 0;

--- a/net/src/mbedtls/mbedtls.c
+++ b/net/src/mbedtls/mbedtls.c
@@ -371,7 +371,7 @@ static int transport_for_socket_type(avs_net_socket_type_t backend_type) {
     case AVS_NET_DTLS_SOCKET:
         return MBEDTLS_SSL_TRANSPORT_DATAGRAM;
     default:
-        assert(0 && "invalid enum value");
+        AVS_ASSERT(0, "invalid enum value");
         return -1;
     }
 }
@@ -419,7 +419,7 @@ static int configure_ssl(ssl_socket_t *socket,
         initialize_cert_security(socket);
         break;
     default:
-        assert(0 && "invalid enum value");
+        AVS_ASSERT(0, "invalid enum value");
         return -1;
     }
 
@@ -859,7 +859,7 @@ static int initialize_ssl_socket(ssl_socket_t *socket,
                                      &configuration->security.data.cert);
         break;
     default:
-        assert(0 && "invalid enum value");
+        AVS_ASSERT(0, "invalid enum value");
         break;
     }
 

--- a/net/src/mbedtls/mbedtls.c
+++ b/net/src/mbedtls/mbedtls.c
@@ -371,7 +371,7 @@ static int transport_for_socket_type(avs_net_socket_type_t backend_type) {
     case AVS_NET_DTLS_SOCKET:
         return MBEDTLS_SSL_TRANSPORT_DATAGRAM;
     default:
-        AVS_ASSERT(0, "invalid enum value");
+        AVS_ASSERT_FAIL("invalid enum value");
         return -1;
     }
 }
@@ -419,7 +419,7 @@ static int configure_ssl(ssl_socket_t *socket,
         initialize_cert_security(socket);
         break;
     default:
-        AVS_ASSERT(0, "invalid enum value");
+        AVS_ASSERT_FAIL("invalid enum value");
         return -1;
     }
 
@@ -859,7 +859,7 @@ static int initialize_ssl_socket(ssl_socket_t *socket,
                                      &configuration->security.data.cert);
         break;
     default:
-        AVS_ASSERT(0, "invalid enum value");
+        AVS_ASSERT_FAIL("invalid enum value");
         break;
     }
 

--- a/net/src/mbedtls/mbedtls.c
+++ b/net/src/mbedtls/mbedtls.c
@@ -371,7 +371,7 @@ static int transport_for_socket_type(avs_net_socket_type_t backend_type) {
     case AVS_NET_DTLS_SOCKET:
         return MBEDTLS_SSL_TRANSPORT_DATAGRAM;
     default:
-        AVS_ASSERT_FAIL("invalid enum value");
+        AVS_UNREACHABLE("invalid enum value");
         return -1;
     }
 }
@@ -419,7 +419,7 @@ static int configure_ssl(ssl_socket_t *socket,
         initialize_cert_security(socket);
         break;
     default:
-        AVS_ASSERT_FAIL("invalid enum value");
+        AVS_UNREACHABLE("invalid enum value");
         return -1;
     }
 
@@ -859,7 +859,7 @@ static int initialize_ssl_socket(ssl_socket_t *socket,
                                      &configuration->security.data.cert);
         break;
     default:
-        AVS_ASSERT_FAIL("invalid enum value");
+        AVS_UNREACHABLE("invalid enum value");
         break;
     }
 

--- a/net/src/openssl/common.h
+++ b/net/src/openssl/common.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #ifndef NET_OPENSSL_COMMON_H
-#define NET_OPENSSL_COMMON_h
+#define NET_OPENSSL_COMMON_H
 
 #include <openssl/err.h>
 

--- a/net/src/openssl/data_loader.c
+++ b/net/src/openssl/data_loader.c
@@ -177,7 +177,7 @@ int _avs_net_openssl_load_ca_certs(SSL_CTX *ctx,
         return load_ca_cert_from_buffer(ctx, info->desc.info.buffer.buffer,
                                         info->desc.info.buffer.buffer_size);
     default:
-        AVS_ASSERT_FAIL("invalid data source");
+        AVS_UNREACHABLE("invalid data source");
         return -1;
     }
     return 0;
@@ -231,7 +231,7 @@ int _avs_net_openssl_load_client_cert(SSL_CTX *ctx,
         return load_client_cert_from_buffer(ctx, info->desc.info.buffer.buffer,
                                             info->desc.info.buffer.buffer_size);
     default:
-        AVS_ASSERT_FAIL("invalid data source");
+        AVS_UNREACHABLE("invalid data source");
         return -1;
     }
     return 0;
@@ -318,7 +318,7 @@ int _avs_net_openssl_load_client_key(SSL_CTX *ctx,
                                            info->desc.info.buffer.buffer_size,
                                            info->desc.info.buffer.password);
     default:
-        AVS_ASSERT_FAIL("invalid data source");
+        AVS_UNREACHABLE("invalid data source");
         return -1;
     }
     return 0;

--- a/net/src/openssl/data_loader.c
+++ b/net/src/openssl/data_loader.c
@@ -177,7 +177,7 @@ int _avs_net_openssl_load_ca_certs(SSL_CTX *ctx,
         return load_ca_cert_from_buffer(ctx, info->desc.info.buffer.buffer,
                                         info->desc.info.buffer.buffer_size);
     default:
-        AVS_ASSERT(0, "invalid data source");
+        AVS_ASSERT_FAIL("invalid data source");
         return -1;
     }
     return 0;
@@ -231,7 +231,7 @@ int _avs_net_openssl_load_client_cert(SSL_CTX *ctx,
         return load_client_cert_from_buffer(ctx, info->desc.info.buffer.buffer,
                                             info->desc.info.buffer.buffer_size);
     default:
-        AVS_ASSERT(0, "invalid data source");
+        AVS_ASSERT_FAIL("invalid data source");
         return -1;
     }
     return 0;
@@ -318,7 +318,7 @@ int _avs_net_openssl_load_client_key(SSL_CTX *ctx,
                                            info->desc.info.buffer.buffer_size,
                                            info->desc.info.buffer.password);
     default:
-        AVS_ASSERT(0, "invalid data source");
+        AVS_ASSERT_FAIL("invalid data source");
         return -1;
     }
     return 0;

--- a/net/src/openssl/data_loader.c
+++ b/net/src/openssl/data_loader.c
@@ -53,7 +53,7 @@ static inline void setup_password_callback(SSL_CTX *ctx, const char *password) {
 static int load_ca_certs_from_paths(SSL_CTX *ctx,
                                     const char *file,
                                     const char *path) {
-    assert(!!file != !!path && "cannot use path and file at the same time");
+    AVS_ASSERT(!!file != !!path, "cannot use path and file at the same time");
     LOG(DEBUG, "CA certificate <file=%s, path=%s>: going to load",
         file ? file : "(null)", path ? path : "(null)");
 
@@ -177,7 +177,7 @@ int _avs_net_openssl_load_ca_certs(SSL_CTX *ctx,
         return load_ca_cert_from_buffer(ctx, info->desc.info.buffer.buffer,
                                         info->desc.info.buffer.buffer_size);
     default:
-        assert(0 && "invalid data source");
+        AVS_ASSERT(0, "invalid data source");
         return -1;
     }
     return 0;
@@ -231,7 +231,7 @@ int _avs_net_openssl_load_client_cert(SSL_CTX *ctx,
         return load_client_cert_from_buffer(ctx, info->desc.info.buffer.buffer,
                                             info->desc.info.buffer.buffer_size);
     default:
-        assert(0 && "invalid data source");
+        AVS_ASSERT(0, "invalid data source");
         return -1;
     }
     return 0;
@@ -318,7 +318,7 @@ int _avs_net_openssl_load_client_key(SSL_CTX *ctx,
                                            info->desc.info.buffer.buffer_size,
                                            info->desc.info.buffer.password);
     default:
-        assert(0 && "invalid data source");
+        AVS_ASSERT(0, "invalid data source");
         return -1;
     }
     return 0;

--- a/net/src/openssl/openssl.c
+++ b/net/src/openssl/openssl.c
@@ -818,7 +818,7 @@ static int configure_ssl(ssl_socket_t *socket,
         }
         break;
     default:
-        AVS_ASSERT(0, "invalid enum value");
+        AVS_ASSERT_FAIL("invalid enum value");
         return -1;
     }
 

--- a/net/src/openssl/openssl.c
+++ b/net/src/openssl/openssl.c
@@ -818,7 +818,7 @@ static int configure_ssl(ssl_socket_t *socket,
         }
         break;
     default:
-        AVS_ASSERT_FAIL("invalid enum value");
+        AVS_UNREACHABLE("invalid enum value");
         return -1;
     }
 

--- a/net/src/openssl/openssl.c
+++ b/net/src/openssl/openssl.c
@@ -818,7 +818,7 @@ static int configure_ssl(ssl_socket_t *socket,
         }
         break;
     default:
-        assert(0 && "invalid enum value");
+        AVS_ASSERT(0, "invalid enum value");
         return -1;
     }
 

--- a/net/src/tinydtls/tinydtls.c
+++ b/net/src/tinydtls/tinydtls.c
@@ -280,7 +280,7 @@ static int configure_ssl(ssl_socket_t *socket,
         }
         break;
     default:
-        AVS_ASSERT_FAIL("invalid enum value");
+        AVS_UNREACHABLE("invalid enum value");
         return -1;
     }
 

--- a/net/src/tinydtls/tinydtls.c
+++ b/net/src/tinydtls/tinydtls.c
@@ -280,7 +280,7 @@ static int configure_ssl(ssl_socket_t *socket,
         }
         break;
     default:
-        AVS_ASSERT(0, "invalid enum value");
+        AVS_ASSERT_FAIL("invalid enum value");
         return -1;
     }
 

--- a/net/src/tinydtls/tinydtls.c
+++ b/net/src/tinydtls/tinydtls.c
@@ -280,7 +280,7 @@ static int configure_ssl(ssl_socket_t *socket,
         }
         break;
     default:
-        assert(0 && "invalid enum value");
+        AVS_ASSERT(0, "invalid enum value");
         return -1;
     }
 

--- a/rbtree/src/rbtree.c
+++ b/rbtree/src/rbtree.c
@@ -221,8 +221,8 @@ AVS_RBTREE(void) avs_rbtree_simple_clone__(AVS_RBTREE_CONST(void) tree,
 }
 
 size_t avs_rbtree_size__(AVS_RBTREE_CONST(void) tree) {
-    assert(!rb_is_cleanup_in_progress(tree)
-           && "avs_rbtree_size__ called while tree deletion in progress");
+    AVS_ASSERT(!rb_is_cleanup_in_progress(tree),
+               "avs_rbtree_size__ called while tree deletion in progress");
     return _AVS_RB_TREE(tree)->size;
 }
 
@@ -273,8 +273,8 @@ AVS_RBTREE_ELEM(void) avs_rbtree_lower_bound__(AVS_RBTREE_CONST(void) tree,
     AVS_RBTREE_ELEM(void) curr;
     AVS_RBTREE_ELEM(void) result;
 
-    assert(!rb_is_cleanup_in_progress(tree)
-           && "avs_rbtree_lower_bound__ called while tree deletion in progress");
+    AVS_ASSERT(!rb_is_cleanup_in_progress(tree),
+               "avs_rbtree_lower_bound__ called while tree deletion in progress");
 
     assert(tree);
     assert(value);
@@ -298,8 +298,8 @@ AVS_RBTREE_ELEM(void) avs_rbtree_upper_bound__(AVS_RBTREE_CONST(void) tree,
     AVS_RBTREE_ELEM(void) curr;
     AVS_RBTREE_ELEM(void) result;
 
-    assert(!rb_is_cleanup_in_progress(tree)
-           && "avs_rbtree_upper_bound__ called while tree deletion in progress");
+    AVS_ASSERT(!rb_is_cleanup_in_progress(tree),
+               "avs_rbtree_upper_bound__ called while tree deletion in progress");
 
     assert(tree);
     assert(value);
@@ -322,8 +322,8 @@ AVS_RBTREE_ELEM(void) avs_rbtree_find__(AVS_RBTREE_CONST(void) tree,
                                         const void *val) {
     AVS_RBTREE_ELEM(void) *elem_ptr;
 
-    assert(!rb_is_cleanup_in_progress(tree)
-           && "avs_rbtree_find__ called while tree deletion in progress");
+    AVS_ASSERT(!rb_is_cleanup_in_progress(tree),
+               "avs_rbtree_find__ called while tree deletion in progress");
 
     elem_ptr = rb_find_ptr(_AVS_RB_TREE((AVS_RBTREE(void))(intptr_t)tree),
                            val, NULL);
@@ -503,8 +503,8 @@ AVS_RBTREE_ELEM(void) avs_rbtree_attach__(AVS_RBTREE(void) tree_,
     AVS_RBTREE_ELEM(void) *dst = NULL;
     AVS_RBTREE_ELEM(void) parent = NULL;
 
-    assert(!rb_is_cleanup_in_progress(rb_tree_const(tree_))
-           && "avs_rbtree_attach__ called while tree deletion in progress");
+    AVS_ASSERT(!rb_is_cleanup_in_progress(rb_tree_const(tree_)),
+               "avs_rbtree_attach__ called while tree deletion in progress");
     assert(tree_);
     assert(elem);
     assert(rb_is_node_detached(elem));
@@ -563,8 +563,8 @@ static AVS_RBTREE_ELEM(void) rb_max(AVS_RBTREE_ELEM(void) root) {
 }
 
 AVS_RBTREE_ELEM(void) avs_rbtree_last__(AVS_RBTREE(void) tree) {
-    assert(!rb_is_cleanup_in_progress(rb_tree_const(tree))
-           && "avs_rbtree_last__ called while tree deletion in progress");
+    AVS_ASSERT(!rb_is_cleanup_in_progress(rb_tree_const(tree)),
+               "avs_rbtree_last__ called while tree deletion in progress");
     return rb_max(_AVS_RB_TREE(tree)->root);
 }
 
@@ -771,14 +771,14 @@ AVS_RBTREE_ELEM(void) avs_rbtree_detach__(AVS_RBTREE(void) tree_,
         return NULL;
     }
 
-    assert(!rb_is_node_detached(elem)
-           && "cannot detach an node that's already detached");
-    assert(!rb_is_cleanup_in_progress(rb_tree_const(tree_))
-           && "avs_rbtree_detach__ called while tree deletion in progress");
+    AVS_ASSERT(!rb_is_node_detached(elem),
+               "cannot detach an node that's already detached");
+    AVS_ASSERT(!rb_is_cleanup_in_progress(rb_tree_const(tree_)),
+               "avs_rbtree_detach__ called while tree deletion in progress");
     assert(tree_);
     assert(elem);
-    assert(rb_is_node_owner(tree_, elem)
-           && "cannot detach node not owned by the tree");
+    AVS_ASSERT(rb_is_node_owner(tree_, elem),
+               "cannot detach node not owned by the tree");
 
     left = _AVS_RB_LEFT(elem);
     right = _AVS_RB_RIGHT(elem);

--- a/utils/src/time.c
+++ b/utils/src/time.c
@@ -244,7 +244,7 @@ static int unit_conv_backward_int64_t_double(int64_t *output,
         tmp = input / (double) conv->factor;
         break;
     default:
-        AVS_ASSERT_FAIL("Invalid unit_conv operation");
+        AVS_UNREACHABLE("Invalid unit_conv operation");
     }
     if (!double_is_int64(tmp)) {
         return -1;

--- a/utils/src/time.c
+++ b/utils/src/time.c
@@ -244,7 +244,7 @@ static int unit_conv_backward_int64_t_double(int64_t *output,
         tmp = input / (double) conv->factor;
         break;
     default:
-        AVS_ASSERT(0, "Invalid unit_conv operation");
+        AVS_ASSERT_FAIL("Invalid unit_conv operation");
     }
     if (!double_is_int64(tmp)) {
         return -1;

--- a/utils/src/time.c
+++ b/utils/src/time.c
@@ -244,7 +244,7 @@ static int unit_conv_backward_int64_t_double(int64_t *output,
         tmp = input / (double) conv->factor;
         break;
     default:
-        assert(0 && "Invalid unit_conv operation");
+        AVS_ASSERT(0, "Invalid unit_conv operation");
     }
     if (!double_is_int64(tmp)) {
         return -1;

--- a/utils/src/x_time_conv.h
+++ b/utils/src/x_time_conv.h
@@ -30,7 +30,7 @@ AVS_CONCAT(unit_conv_, SCALAR_TYPE, _int64_t)(SCALAR_TYPE *output,
         *output = (SCALAR_TYPE) input / (SCALAR_TYPE) factor;
         return 0;
     default:
-        AVS_ASSERT(0, "Invalid unit_conv operation");
+        AVS_ASSERT_FAIL("Invalid unit_conv operation");
         return -1;
     }
 }

--- a/utils/src/x_time_conv.h
+++ b/utils/src/x_time_conv.h
@@ -30,7 +30,7 @@ AVS_CONCAT(unit_conv_, SCALAR_TYPE, _int64_t)(SCALAR_TYPE *output,
         *output = (SCALAR_TYPE) input / (SCALAR_TYPE) factor;
         return 0;
     default:
-        AVS_ASSERT_FAIL("Invalid unit_conv operation");
+        AVS_UNREACHABLE("Invalid unit_conv operation");
         return -1;
     }
 }

--- a/utils/src/x_time_conv.h
+++ b/utils/src/x_time_conv.h
@@ -30,7 +30,7 @@ AVS_CONCAT(unit_conv_, SCALAR_TYPE, _int64_t)(SCALAR_TYPE *output,
         *output = (SCALAR_TYPE) input / (SCALAR_TYPE) factor;
         return 0;
     default:
-        assert(0 && "Invalid unit_conv operation");
+        AVS_ASSERT(0, "Invalid unit_conv operation");
         return -1;
     }
 }

--- a/vector/src/vector.c
+++ b/vector/src/vector.c
@@ -41,9 +41,9 @@ static const uint64_t magic = 0xb5e4189902ba0aaULL;
 
 static avs_vector_desc_t *get_desc(void **ptr) {
     avs_vector_desc_t *desc;
-    assert(ptr && "NULL vector pointer");
+    AVS_ASSERT(ptr, "NULL vector pointer");
     desc = AVS_VECTOR_DESC__(ptr);
-    assert(desc->magic == magic && "invalid vector pointer");
+    AVS_ASSERT(desc->magic == magic, "invalid vector pointer");
     return desc;
 }
 


### PR DESCRIPTION
AVS_ASSERT is supposed to provide an assertion with a string literal message defined in a way that does not trigger compiler warnings.

AVS_UNREACHABLE is an unconditional assertion failure with a custom message.