### PR TITLE
Refactor add_module_with_include_dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,15 +371,22 @@ set(MODULE_INCLUDE_DIRS)
 # Named arguments:
 # PATH - relative path to the module subdirectory. If not given, NAME is used instead.
 # NAME - module name, used as a substring of output library name and Makefile targets
-# INCLUDE_DIRS_VAR - name of the variable to append module include dirs to
+# INCLUDE_DIRS_VAR - name of the variable to append module include dirs to. If not set,
+#                    MODULE_INCLUDE_DIRS is assumed.
 function(add_module_with_include_dirs)
     set(options)
     set(one_value_args PATH NAME INCLUDE_DIRS_VAR)
     set(multi_value_args)
     cmake_parse_arguments(AMWID "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
 
+    if(NOT DEFINED AMWID_NAME)
+        message(FATAL_ERROR "Required argument NAME not given")
+    endif()
     if(NOT DEFINED AMWID_PATH)
         set(AMWID_PATH "${AMWID_NAME}")
+    endif()
+    if(NOT DEFINED INCLUDE_DIRS_VAR)
+        set(AMWID_INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
     endif()
 
     add_subdirectory(${AMWID_PATH})
@@ -405,8 +412,7 @@ function(add_module_with_include_dirs)
 endfunction()
 
 if(WITH_AVS_UNIT)
-    add_module_with_include_dirs(NAME unit
-                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME unit)
 endif()
 
 if(WITH_TEST)
@@ -477,28 +483,23 @@ else(WITH_TEST)
 endif(WITH_TEST)
 
 if(WITH_AVS_ALGORITHM)
-    add_module_with_include_dirs(NAME algorithm
-                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME algorithm)
 endif()
 
 if(WITH_AVS_BUFFER)
-    add_module_with_include_dirs(NAME buffer
-                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME buffer)
 endif()
 
 if(WITH_AVS_LIST)
-    add_module_with_include_dirs(NAME list
-                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME list)
 endif()
 
 if(WITH_AVS_VECTOR)
-    add_module_with_include_dirs(NAME vector
-                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME vector)
 endif()
 
 if(WITH_AVS_UTILS)
-    add_module_with_include_dirs(NAME utils
-                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME utils)
 endif()
 
 if(WITH_AVS_NET)
@@ -523,23 +524,19 @@ if(WITH_AVS_NET)
         endif()
     endif()
 
-    add_module_with_include_dirs(NAME net
-                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME net)
 endif()
 
 if(WITH_AVS_STREAM)
-    add_module_with_include_dirs(NAME stream
-                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME stream)
 endif()
 
 if(WITH_AVS_LOG)
-    add_module_with_include_dirs(NAME log
-                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME log)
 endif()
 
 if (WITH_AVS_RBTREE)
-    add_module_with_include_dirs(NAME rbtree
-                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME rbtree)
 endif()
 
 cmake_dependent_option(WITH_AVS_COAP_MESSAGE_CACHE
@@ -550,16 +547,14 @@ cmake_dependent_option(WITH_AVS_COAP_NET_STATS
                        ON WITH_AVS_COAP OFF)
 
 if(WITH_AVS_COAP)
-    add_module_with_include_dirs(NAME coap
-                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME coap)
 endif()
 
 cmake_dependent_option(WITH_AVS_HTTP_ZLIB
                        "Enable support for HTTP compression using zlib"
                        ON WITH_AVS_HTTP OFF)
 if(WITH_AVS_HTTP)
-    add_module_with_include_dirs(NAME http
-                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME http)
     if(WITH_AVS_HTTP_ZLIB)
         if(NOT ZLIB_FOUND)
             message(FATAL_ERROR "zlib not found")
@@ -572,8 +567,7 @@ if(WITH_AVS_HTTP)
 endif()
 
 if(WITH_AVS_PERSISTENCE)
-    add_module_with_include_dirs(NAME persistence
-                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME persistence)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,29 +368,45 @@ endmacro()
 
 set(MODULE_INCLUDE_DIRS)
 
-macro(add_module_with_include_dirs MODULE_NAME MODULE_INCLUDE_DIRS_VAR)
-    add_subdirectory(${MODULE_NAME})
-    include_directories(${avs_${MODULE_NAME}_INCLUDE_DIRS})
-    # Append module includes to a specified variable name (i.e. MODULE_INCLUDE_DIRS_VAR).
-    set(${MODULE_INCLUDE_DIRS_VAR}
-        "${${MODULE_INCLUDE_DIRS_VAR}}"
-        "${avs_${MODULE_NAME}_INCLUDE_DIRS}")
+# Named arguments:
+# PATH - relative path to the module subdirectory. If not given, NAME is used instead.
+# NAME - module name, used as a substring of output library name and Makefile targets
+# INCLUDE_DIRS_VAR - name of the variable to append module include dirs to
+function(add_module_with_include_dirs)
+    set(options)
+    set(one_value_args PATH NAME INCLUDE_DIRS_VAR)
+    set(multi_value_args)
+    cmake_parse_arguments(AMWID "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
 
-    if(TARGET avs_${MODULE_NAME}_check)
-        add_test(NAME test_avs_${MODULE_NAME}_symbols
-                 COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_symbols.sh $<TARGET_FILE:avs_${MODULE_NAME}> avs_ AVS_ _avs _AVS_)
-        add_dependencies(avs_commons_symbols_check avs_${MODULE_NAME})
+    if(NOT DEFINED AMWID_PATH)
+        set(AMWID_PATH "${AMWID_NAME}")
     endif()
-    file(GLOB_RECURSE MODULE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_NAME}/*.c
-                                   ${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_NAME}/*h)
+
+    add_subdirectory(${AMWID_PATH})
+    include_directories(${avs_${AMWID_NAME}_INCLUDE_DIRS})
+
+    # Append module includes to a specified variable name (i.e. MODULE_INCLUDE_DIRS_VAR).
+    set(${AMWID_INCLUDE_DIRS_VAR}
+        ${${AMWID_INCLUDE_DIRS_VAR}}
+        ${avs_${AMWID_NAME}_INCLUDE_DIRS}
+        PARENT_SCOPE)
+
+    if(TARGET avs_${AMWID_NAME}_check)
+        add_test(NAME test_avs_${AMWID_NAME}_symbols
+                 COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_symbols.sh $<TARGET_FILE:avs_${AMWID_NAME}> avs_ AVS_ _avs _AVS_)
+        add_dependencies(avs_commons_symbols_check avs_${AMWID_NAME})
+    endif()
+    file(GLOB_RECURSE MODULE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${AMWID_PATH}/*.c
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/${AMWID_PATH}/*.h)
     foreach(F ${MODULE_FILES})
         add_test(NAME test_${F}_visibility COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_visibility.py ${F})
         add_test(NAME test_${F}_headers COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_headers.py ${F})
     endforeach()
-endmacro()
+endfunction()
 
 if(WITH_AVS_UNIT)
-    add_module_with_include_dirs(unit MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME unit
+                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
 endif()
 
 if(WITH_TEST)
@@ -461,23 +477,28 @@ else(WITH_TEST)
 endif(WITH_TEST)
 
 if(WITH_AVS_ALGORITHM)
-    add_module_with_include_dirs(algorithm MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME algorithm
+                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
 endif()
 
 if(WITH_AVS_BUFFER)
-    add_module_with_include_dirs(buffer MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME buffer
+                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
 endif()
 
 if(WITH_AVS_LIST)
-    add_module_with_include_dirs(list MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME list
+                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
 endif()
 
 if(WITH_AVS_VECTOR)
-    add_module_with_include_dirs(vector MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME vector
+                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
 endif()
 
 if(WITH_AVS_UTILS)
-    add_module_with_include_dirs(utils MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME utils
+                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
 endif()
 
 if(WITH_AVS_NET)
@@ -502,19 +523,23 @@ if(WITH_AVS_NET)
         endif()
     endif()
 
-    add_module_with_include_dirs(net MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME net
+                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
 endif()
 
 if(WITH_AVS_STREAM)
-    add_module_with_include_dirs(stream MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME stream
+                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
 endif()
 
 if(WITH_AVS_LOG)
-    add_module_with_include_dirs(log MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME log
+                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
 endif()
 
 if (WITH_AVS_RBTREE)
-    add_module_with_include_dirs(rbtree MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME rbtree
+                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
 endif()
 
 cmake_dependent_option(WITH_AVS_COAP_MESSAGE_CACHE
@@ -525,14 +550,16 @@ cmake_dependent_option(WITH_AVS_COAP_NET_STATS
                        ON WITH_AVS_COAP OFF)
 
 if(WITH_AVS_COAP)
-    add_module_with_include_dirs(coap MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME coap
+                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
 endif()
 
 cmake_dependent_option(WITH_AVS_HTTP_ZLIB
                        "Enable support for HTTP compression using zlib"
                        ON WITH_AVS_HTTP OFF)
 if(WITH_AVS_HTTP)
-    add_module_with_include_dirs(http MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME http
+                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
     if(WITH_AVS_HTTP_ZLIB)
         if(NOT ZLIB_FOUND)
             message(FATAL_ERROR "zlib not found")
@@ -545,7 +572,8 @@ if(WITH_AVS_HTTP)
 endif()
 
 if(WITH_AVS_PERSISTENCE)
-    add_module_with_include_dirs(persistence MODULE_INCLUDE_DIRS)
+    add_module_with_include_dirs(NAME persistence
+                                 INCLUDE_DIRS_VAR MODULE_INCLUDE_DIRS)
 endif()
 
 


### PR DESCRIPTION
It now uses `cmake_parse_arguments` for argument parsing and supports optional `INCLUDE_DIRS_VAR`.