### PR TITLE
avs_compat_threading fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,7 @@ option(WITH_AVS_RBTREE "AVSystem generic red-black tree implementation" ${MODULE
 option(WITH_AVS_COAP "AVSystem CoAP abstraction layer" ${MODULES_ENABLED})
 option(WITH_AVS_HTTP "AVSystem HTTP client" ${MODULES_ENABLED})
 option(WITH_AVS_PERSISTENCE "AVSystem persistence framework" ${MODULES_ENABLED})
-option(WITH_AVS_THREADING "Use multithreading utility compatibility layer" ${MODULES_ENABLED})
+option(WITH_AVS_COMPAT_THREADING "Use multithreading utility compatibility layer" ${MODULES_ENABLED})
 
 cmake_dependent_option(WITH_INTERNAL_LOGS "Enable logging from inside AVSystem Commons libraries" ON WITH_AVS_LOG OFF)
 cmake_dependent_option(WITH_INTERNAL_TRACE "Enable TRACE-level logs inside AVSystem Commons libraries" OFF WITH_INTERNAL_LOGS OFF)
@@ -580,7 +580,7 @@ if(WITH_AVS_PERSISTENCE)
     add_module_with_include_dirs(NAME persistence)
 endif()
 
-if(WITH_AVS_THREADING)
+if(WITH_AVS_COMPAT_THREADING)
     add_module_with_include_dirs(NAME compat_threading
                                  PATH compat/threading)
 endif()

--- a/compat/threading/CMakeLists.txt
+++ b/compat/threading/CMakeLists.txt
@@ -40,6 +40,6 @@ if(NOT TARGET avs_compat_threading)
 endif()
 
 install(DIRECTORY include_public/
-        COMPONENT threading
+        COMPONENT compat_threading
         DESTINATION ${INCLUDE_INSTALL_DIR}
         FILES_MATCHING REGEX "[.]h$")

--- a/compat/threading/CMakeLists.txt
+++ b/compat/threading/CMakeLists.txt
@@ -37,6 +37,7 @@ if(NOT TARGET avs_compat_threading)
     # Add fake avs_compat_threading "library" just so that other components
     # have something to link to
     add_library(avs_compat_threading INTERFACE)
+    avs_install_export(avs_compat_threading compat_threading)
 endif()
 
 install(DIRECTORY include_public/

--- a/compat/threading/CMakeLists.txt
+++ b/compat/threading/CMakeLists.txt
@@ -31,6 +31,14 @@ include_directories(${INCLUDE_DIRS})
 add_subdirectory(src/atomic_spinlock)
 add_subdirectory(src/pthread)
 
+if(NOT TARGET avs_compat_threading)
+    message(WARNING "No default implementation of threading compatibility layer! "
+            "Some symbols will need to be user-provided.")
+    # Add fake avs_compat_threading "library" just so that other components
+    # have something to link to
+    add_library(avs_compat_threading INTERFACE)
+endif()
+
 install(DIRECTORY include_public/
         COMPONENT threading
         DESTINATION ${INCLUDE_INSTALL_DIR}

--- a/compat/threading/src/atomic_spinlock/CMakeLists.txt
+++ b/compat/threading/src/atomic_spinlock/CMakeLists.txt
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-option(WITH_AVS_THREADING_ATOMIC_SPINLOCK "Enable threading primitives implementation based on spinlocks and C11 atomics" ${HAVE_C11_STDATOMIC})
-if(NOT WITH_AVS_THREADING_ATOMIC_SPINLOCK)
+option(WITH_AVS_COMPAT_THREADING_ATOMIC_SPINLOCK "Enable threading primitives implementation based on spinlocks and C11 atomics" ${HAVE_C11_STDATOMIC})
+if(NOT WITH_AVS_COMPAT_THREADING_ATOMIC_SPINLOCK)
     return()
 endif()
 

--- a/compat/threading/src/pthread/CMakeLists.txt
+++ b/compat/threading/src/pthread/CMakeLists.txt
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 find_package(Threads)
-cmake_dependent_option(WITH_AVS_THREADING_PTHREAD "Enable threading primitives implementation based on pthreads" ON THREADS_FOUND OFF)
-if(NOT WITH_AVS_THREADING_PTHREAD)
+cmake_dependent_option(WITH_AVS_COMPAT_THREADING_PTHREAD "Enable threading primitives implementation based on pthreads" ON THREADS_FOUND OFF)
+if(NOT WITH_AVS_COMPAT_THREADING_PTHREAD)
     return()
 endif()
 

--- a/config/avs_commons_config.h.in
+++ b/config/avs_commons_config.h.in
@@ -104,4 +104,4 @@ extern void *sbrk (intptr_t __delta);
 
 #cmakedefine WITH_AVS_HTTP_ZLIB
 
-#cmakedefine WITH_AVS_THREADING
+#cmakedefine WITH_AVS_COMPAT_THREADING

--- a/log/CMakeLists.txt
+++ b/log/CMakeLists.txt
@@ -34,7 +34,7 @@ set(avs_log_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include_public" PARENT_SCO
 add_library(avs_log STATIC ${ALL_SOURCES})
 target_link_libraries(avs_log avs_list)
 
-if(WITH_AVS_THREADING)
+if(WITH_AVS_COMPAT_THREADING)
     target_link_libraries(avs_log avs_compat_threading)
 endif()
 

--- a/log/src/log.c
+++ b/log/src/log.c
@@ -22,10 +22,10 @@
 #include <avsystem/commons/list.h>
 #include <avsystem/commons/log.h>
 
-#ifdef WITH_AVS_THREADING
+#ifdef WITH_AVS_COMPAT_THREADING
 # include <avsystem/commons/mutex.h>
 # include <avsystem/commons/init_once.h>
-#endif // WITH_AVS_THREADING
+#endif // WITH_AVS_COMPAT_THREADING
 
 VISIBILITY_SOURCE_BEGIN
 
@@ -56,7 +56,7 @@ static struct {
     .module_levels = NULL
 };
 
-#ifdef WITH_AVS_THREADING
+#ifdef WITH_AVS_COMPAT_THREADING
 static avs_mutex_t *g_log_mutex;
 static avs_init_once_handle_t g_log_init_handle;
 
@@ -94,12 +94,12 @@ static int _log_lock(const char *init_fail_msg,
               "could not lock log mutex")
 # define LOG_UNLOCK() avs_mutex_unlock(g_log_mutex)
 
-#else // WITH_AVS_THREADING
+#else // WITH_AVS_COMPAT_THREADING
 
 # define LOG_LOCK() 0
 # define LOG_UNLOCK()
 
-#endif // WITH_AVS_THREADING
+#endif // WITH_AVS_COMPAT_THREADING
 
 static inline void set_log_handler_unlocked(avs_log_handler_t *log_handler) {
     g_log.handler = log_handler;

--- a/utils/include_public/avsystem/commons/cleanup.h
+++ b/utils/include_public/avsystem/commons/cleanup.h
@@ -28,7 +28,8 @@ extern "C" {
  * performed by the user. Due to this, and care for backwards compatibility
  * there is no method for explicit initialization. The initialization itself is
  * thread-safe as long as threading layer is implemented correctly -- either by
- * means of WITH_AVS_THREADING CMake option, or by the platform integrator.
+ * means of WITH_AVS_COMPAT_THREADING CMake option, or by the platform
+ * integrator.
  *
  * NOTE: Cleaning up resources leaves AvsCommons in an operational state.
  */


### PR DESCRIPTION
* Provide fake avs_compat_threading 'library' when no default implementation is available
* Rename WITH_AVS_THREADING to WITH_AVS_COMPAT_THREADING