### PR TITLE
Add support for `signed char` in `ASSERT_EQ`

### DIFF
--- a/unit/include_public/avsystem/commons/unit/test.h
+++ b/unit/include_public/avsystem/commons/unit/test.h
@@ -225,6 +225,8 @@ __builtin_choose_expr(__builtin_types_compatible_p(__typeof__(actual), bool),\
 AVS_UNIT_CHECK_BOOL__(actual, expected, strings,\
 __builtin_choose_expr(__builtin_types_compatible_p(__typeof__(actual), char),\
     avs_unit_check_equal_c__((char) (actual), (char) (expected), (strings)),\
+__builtin_choose_expr(__builtin_types_compatible_p(__typeof__(actual), signed char),\
+    avs_unit_check_equal_sc__((signed char) (actual), (signed char) (expected), (strings)),\
 __builtin_choose_expr(__builtin_types_compatible_p(__typeof__(actual), short),\
     avs_unit_check_equal_s__((short) (actual), (short) (expected), (strings)),\
 __builtin_choose_expr(__builtin_types_compatible_p(__typeof__(actual), int),\
@@ -250,11 +252,12 @@ __builtin_choose_expr(__builtin_types_compatible_p(__typeof__(actual), double),\
 __builtin_choose_expr(__builtin_types_compatible_p(__typeof__(actual), long double),\
     avs_unit_check_equal_ld__((long double) (actual), (long double) (expected), (strings)),\
     avs_unit_abort__("AVS_UNIT_ASSERT_EQUAL called for unsupported data type\n", __FILE__, __LINE__)\
-))))))))))))))
+)))))))))))))))
 
 #endif /* __cplusplus */
 
 AVS_UNIT_CHECK_EQUAL_FUNCTION__(char, c)
+AVS_UNIT_CHECK_EQUAL_FUNCTION__(signed char, sc)
 AVS_UNIT_CHECK_EQUAL_FUNCTION__(short, s)
 AVS_UNIT_CHECK_EQUAL_FUNCTION__(int, i)
 AVS_UNIT_CHECK_EQUAL_FUNCTION__(long, l)

--- a/unit/src/test.c
+++ b/unit/src/test.c
@@ -256,6 +256,7 @@ void avs_unit_assert_false__(int result,
                      isnan(actual) ? isnan(expected) : actual == expected)
 
 AVS_UNIT_CHECK_EQUAL_FUNCTION_DECLARE__(char, c) CHECK_EQUAL_BODY_INT("%c")
+AVS_UNIT_CHECK_EQUAL_FUNCTION_DECLARE__(signed char, sc) CHECK_EQUAL_BODY_INT("%d")
 AVS_UNIT_CHECK_EQUAL_FUNCTION_DECLARE__(short, s) CHECK_EQUAL_BODY_INT("%d")
 AVS_UNIT_CHECK_EQUAL_FUNCTION_DECLARE__(int, i) CHECK_EQUAL_BODY_INT("%d")
 AVS_UNIT_CHECK_EQUAL_FUNCTION_DECLARE__(long, l) CHECK_EQUAL_BODY_INT("%ld")


### PR DESCRIPTION
Attempt to use `signed char` in `ASSERT_EQ` failed, because we took
care to handle all types except for `signed char`, foolishly believing
that `char` and `unsigned char` is enough.

Of course it isn't. It's C after all.

In C and C++, `char` may be either signed or unsigned, which does not
mean that `char` is ever fully equivalent to `signed char` or `unsigned
char`. No, each one is a completely separate type, unlike every single
other integral type, which is either implicitly signed, or explicitly
unsigned.

When attempting to force the compiler to display any kind of warning
whenever an implicit `enum -> int` conversion is performed, I enabled
`-fshort-enums` GCC flag, which causes all enums to be backed by
smallest possible numeric type able to hold all enum values instead of
`int`. Which made the `ASSERT_EQ` fail when it was used to compare
a two-value enum that may be equal to either -1 or 0. After enabling
this flag, the best numeric type GCC was able to use of course was not
`char`, oh no - we can't be sure whether it's signed or not after all.
The best one was `signed char`. Which caused an oh-so-helpful error
message:

`error: invalid use of void expression`

`signed char`, I hate you so much.