### PR TITLE
Make .in files not break on clang-format

### DIFF
--- a/config/avs_commons_config.h.in
+++ b/config/avs_commons_config.h.in
@@ -47,7 +47,9 @@
 #cmakedefine WITH_TLS_SESSION_PERSISTENCE
 
 #cmakedefine WITH_AVS_LOG
+/* clang-format off */
 #cmakedefine AVS_LOG_MAX_LINE_LENGTH @AVS_LOG_MAX_LINE_LENGTH@
+/* clang-format on */
 #cmakedefine AVS_LOG_USE_GLOBAL_BUFFER
 
 #cmakedefine WITH_INTERNAL_LOGS
@@ -82,7 +84,9 @@ extern void *sbrk (intptr_t __delta);
 #cmakedefine HAVE_PRAGMA_DIAGNOSTIC
 
 #ifndef AVS_UNIT_TESTING
+/* clang-format off */
 #cmakedefine HAVE_VISIBILITY
+/* clang-format on */
 #endif
 
 #if defined(HAVE_VISIBILITY)

--- a/include_public/avsystem/commons/defs.h.in
+++ b/include_public/avsystem/commons/defs.h.in
@@ -45,7 +45,9 @@ extern "C" {
 #endif
 
 #ifndef IF_NAMESIZE
-#    cmakedefine HAVE_NET_IF_H
+/* clang-format off */
+#cmakedefine HAVE_NET_IF_H
+/* clang-format on */
 #    ifdef HAVE_NET_IF_H
 #        include <net/if.h>
 #    else
@@ -54,7 +56,9 @@ extern "C" {
 #endif // IF_NAMESIZE
 
 #ifndef AVS_SSIZE_T_DEFINED
-#    cmakedefine HAVE_SYS_TYPES_H
+/* clang-format off */
+#cmakedefine HAVE_SYS_TYPES_H
+/* clang-format on */
 #    ifdef HAVE_SYS_TYPES_H
 #        include <sys/types.h>
 #    else
@@ -403,6 +407,8 @@ struct AvsCallWithCast__ {
 
 #define AVS_PRAGMA(x) _Pragma(#x)
 
+/* clang-format off */
 #define AVS_POISON(identifier) @AVS_POISON_IMPL@
+/* clang-format on */
 
 #endif /* AVS_COMMONS_DEFS_H */


### PR DESCRIPTION
clang-format tends to:
- replace `#cmakedefine` inside `#if`/`#ifdef` with `#   cmakedefine`,
  which breaks CMake at least until 3.7, while our CMakeLists claim we
  support 3.4+
- replace `@FOO@` with `@FOO @` for some reason (maybe it thinks the
  source is ObjC or something?)