### PR TITLE
Split avs_crypto into avs_crypto_openssl/avs_crypto_mbedtls

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -12,56 +12,67 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(avs_crypto STATIC
-            include_public/avsystem/commons/hkdf.h
-            include_public/avsystem/commons/aead.h
+set(AVS_CRYPTO_SOURCES
+    include_public/avsystem/commons/hkdf.h
+    include_public/avsystem/commons/aead.h
 
-            src/crypto_utils.c
-            src/crypto_utils.h)
+    src/crypto_utils.c
+    src/crypto_utils.h)
 
-target_include_directories(avs_crypto PUBLIC
+add_library(avs_crypto_core INTERFACE)
+target_include_directories(avs_crypto_core INTERFACE
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include_public>
                            $<INSTALL_INTERFACE:include>)
-target_link_libraries(avs_crypto PUBLIC avs_commons_global_headers avs_utils)
-
-avs_add_test(NAME avs_crypto
-             LIBS avs_crypto
-             SOURCES $<TARGET_PROPERTY:avs_crypto,SOURCES>)
-
-if(TARGET avs_crypto_test)
-    target_sources(avs_crypto_test PRIVATE
-                   src/test/hkdf.c
-                   src/test/aead.c)
-endif()
-
-if(WITH_OPENSSL)
-    if (OPENSSL_VERSION VERSION_LESS 1.1.0)
-        message(FATAL_ERROR "avs_crypto requires OpenSSL 1.1.0 or newer")
-    endif()
-    target_sources(avs_crypto PRIVATE
-                   src/openssl/hkdf.c
-                   src/openssl/aead.c)
-    target_link_libraries(avs_crypto PUBLIC OpenSSL::Crypto)
-elseif(WITH_MBEDTLS)
-    if (MBEDTLS_VERSION VERSION_LESS 2.14.0)
-        message(FATAL_ERROR "avs_crypto requires mbed TLS 2.14.0 or newer")
-    endif()
-    target_sources(avs_crypto PRIVATE
-                   src/mbedtls/hkdf.c
-                   src/mbedtls/aead.c)
-    target_link_libraries(avs_crypto PUBLIC mbedcrypto)
-elseif(WITH_TINYDTLS)
-    message(FATAL_ERROR "avs_crypto does not support tinydtls")
-else()
-    message(FATAL_ERROR "No crypto backend specified")
-endif()
+target_link_libraries(avs_crypto_core INTERFACE avs_commons_global_headers avs_utils)
 
 if(WITH_INTERNAL_LOGS)
-    target_link_libraries(avs_crypto PUBLIC avs_log)
+    target_link_libraries(avs_crypto_core INTERFACE avs_log)
 endif()
 
-avs_install_export(avs_crypto crypto)
-install(DIRECTORY include_public/
-        COMPONENT crypto
-        DESTINATION ${INCLUDE_INSTALL_DIR}
-        FILES_MATCHING REGEX "[.]h$")
+if(WITH_OPENSSL AND OPENSSL_VERSION VERSION_GREATER_EQUAL 1.1.0)
+    add_library(avs_crypto_openssl
+                ${AVS_CRYPTO_SOURCES}
+                src/openssl/hkdf.c
+                src/openssl/aead.c)
+    target_link_libraries(avs_crypto_openssl PUBLIC avs_crypto_core OpenSSL::Crypto)
+
+    avs_add_test(NAME avs_crypto_openssl
+                 LIBS avs_crypto_openssl
+                 SOURCES
+                 src/test/hkdf.c
+                 src/test/aead.c)
+    avs_install_export(avs_crypto_openssl crypto)
+endif()
+
+if(WITH_MBEDTLS AND MBEDTLS_VERSION VERSION_GREATER_EQUAL 2.14.0)
+    add_library(avs_crypto_mbedtls
+                ${AVS_CRYPTO_SOURCES}
+                src/mbedtls/hkdf.c
+                src/mbedtls/aead.c)
+    target_link_libraries(avs_crypto_mbedtls PUBLIC avs_crypto_core mbedcrypto)
+
+    avs_add_test(NAME avs_crypto_mbedtls
+                 LIBS avs_crypto_mbedtls
+                 SOURCES
+                 src/test/hkdf.c
+                 src/test/aead.c)
+    avs_install_export(avs_crypto_mbedtls crypto)
+endif()
+
+# alias avs_net to first available implementation
+foreach(target IN ITEMS avs_crypto_mbedtls avs_crypto_openssl)
+    if(TARGET "${target}")
+        add_library(avs_crypto ALIAS "${target}")
+        break()
+    endif()
+endforeach()
+
+if(NOT TARGET avs_crypto)
+    message(WARNING "No supported crypto backend available, avs_crypto will be disabled")
+else()
+    install(DIRECTORY include_public/
+            COMPONENT crypto
+            DESTINATION ${INCLUDE_INSTALL_DIR}
+            FILES_MATCHING REGEX "[.]h$")
+    avs_install_export(avs_crypto_core crypto)
+endif()


### PR DESCRIPTION
Similarly to what `avs_net` currently does. `avs_crypto` is an alias to the
first available concrete implementation. Allows for building both
OpenSSL and mbed TLS backends at the same time, and running tests for
both.