### PR TITLE
Remove AVS_NET_ETIMEDOUT forward declaration

### DIFF
--- a/net/compat/posix/net_impl.c
+++ b/net/compat/posix/net_impl.c
@@ -44,8 +44,6 @@ VISIBILITY_SOURCE_BEGIN
 #    define INET_ADDRSTRLEN 16
 #endif
 
-extern const int AVS_NET_ETIMEDOUT;
-
 static const avs_time_duration_t NET_SEND_TIMEOUT = { 30, 0 };
 static const avs_time_duration_t NET_CONNECT_TIMEOUT = { 10, 0 };
 static const avs_time_duration_t NET_ACCEPT_TIMEOUT = { 5, 0 };


### PR DESCRIPTION
It was only a forward declaration, and completely unused.