### PR TITLE
Implement micro log feature. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ option(WITH_AVS_PERSISTENCE "AVSystem persistence framework" ${MODULES_ENABLED})
 option(WITH_AVS_SCHED "AVSystem job scheduler" ${MODULES_ENABLED})
 option(WITH_AVS_COMPAT_THREADING "Use multithreading utility compatibility layer" ${MODULES_ENABLED})
 option(WITH_AVS_CRYPTO "Cryptogaphic functions abstraction layer" ${MODULES_ENABLED})
+option(WITH_AVS_MICRO_LOGS "Replaces all invocations of AVS_DISPOSABLE_LOG() with single space. This saves a lot on binary size in applications that log a lot." OFF)
 
 include(CMakeDependentOption)
 cmake_dependent_option(WITH_INTERNAL_LOGS "Enable logging from inside AVSystem Commons libraries" ON WITH_AVS_LOG OFF)

--- a/buffer/src/buffer.c
+++ b/buffer/src/buffer.c
@@ -60,7 +60,7 @@ int avs_buffer_create(avs_buffer_t **buffer_ptr, size_t capacity) {
         avs_buffer_reset(*buffer_ptr);
         return 0;
     } else {
-        LOG(ERROR, "cannot allocate buffer");
+        LOG(ERROR, _("cannot allocate buffer"));
         return -1;
     }
 }
@@ -98,7 +98,7 @@ char *avs_buffer_raw_insert_ptr(avs_buffer_t *buffer) {
 
 int avs_buffer_consume_bytes(avs_buffer_t *buffer, size_t bytes_count) {
     if (bytes_count > avs_buffer_data_size(buffer)) {
-        LOG(ERROR, "not enough data");
+        LOG(ERROR, _("not enough data"));
         return -1;
     }
     buffer->begin += bytes_count;
@@ -110,7 +110,7 @@ int avs_buffer_append_bytes(avs_buffer_t *buffer,
                             const void *data,
                             size_t data_length) {
     if (data_length > avs_buffer_space_left(buffer)) {
-        LOG(ERROR, "buffer too small");
+        LOG(ERROR, _("buffer too small"));
         return -1;
     } else {
         if (data_length > space_left_without_moving(buffer)) {
@@ -124,7 +124,7 @@ int avs_buffer_append_bytes(avs_buffer_t *buffer,
 
 int avs_buffer_advance_ptr(avs_buffer_t *buffer, size_t n) {
     if (n > avs_buffer_space_left(buffer)) {
-        LOG(ERROR, "position out of bounds");
+        LOG(ERROR, _("position out of bounds"));
         return -1;
     } else {
         if (n > space_left_without_moving(buffer)) {

--- a/coap/src/block_builder.c
+++ b/coap/src/block_builder.c
@@ -105,7 +105,7 @@ avs_coap_block_builder_build(avs_coap_block_builder_t *builder,
                "payload buffer MUST be able to hold more than a single block");
 
     if (builder->read_offset == builder->write_offset) {
-        LOG(WARNING, "no payload data to extract!");
+        LOG(WARNING, _("no payload data to extract!"));
         return NULL;
     }
 

--- a/coap/src/block_utils.c
+++ b/coap/src/block_utils.c
@@ -37,7 +37,7 @@ int avs_coap_get_block_info(const avs_coap_msg_t *msg,
     if (avs_coap_msg_find_unique_opt(msg, opt_number, &opt)) {
         if (opt) {
             int num = opt_number == AVS_COAP_OPT_BLOCK1 ? 1 : 2;
-            LOG(ERROR, "multiple BLOCK%d options found", num);
+            LOG(ERROR, _("multiple BLOCK") "%d" _(" options found"), num);
             return -1;
         }
         return 0;

--- a/coap/src/ctx.c
+++ b/coap/src/ctx.c
@@ -59,7 +59,7 @@ int avs_coap_ctx_create(avs_coap_ctx_t **ctx, size_t msg_cache_size) {
     if (msg_cache_size > 0) {
         (*ctx)->msg_cache = _avs_coap_msg_cache_create(msg_cache_size);
         if (!(*ctx)->msg_cache) {
-            LOG(ERROR, "could not create message cache");
+            LOG(ERROR, _("could not create message cache"));
             avs_free(*ctx);
             return -1;
         }
@@ -121,7 +121,7 @@ static int map_io_error(const char *operation, avs_error_t err) {
     }
 
     if (err.category == AVS_ERRNO_CATEGORY) {
-        LOG(ERROR, "%s failed: %s", operation,
+        LOG(ERROR,  "%s" _(" failed: ") "%s" , operation,
             avs_strerror((avs_errno_t) err.code));
         if (err.code == AVS_ETIMEDOUT) {
             return AVS_COAP_CTX_ERR_TIMEOUT;
@@ -129,7 +129,7 @@ static int map_io_error(const char *operation, avs_error_t err) {
             return AVS_COAP_CTX_ERR_MSG_TOO_LONG;
         }
     } else {
-        LOG(ERROR, "%s failed", operation);
+        LOG(ERROR,  "%s" _(" failed"), operation);
     }
     return AVS_COAP_CTX_ERR_NETWORK;
 }
@@ -150,7 +150,7 @@ static int try_cache_response(avs_coap_ctx_t *ctx,
     if (avs_is_err(avs_net_socket_get_remote_host(socket, addr, sizeof(addr)))
             || avs_is_err(avs_net_socket_get_remote_port(socket, port,
                                                          sizeof(port)))) {
-        LOG(DEBUG, "could not get remote host/port");
+        LOG(DEBUG, _("could not get remote host/port"));
         return -1;
     }
 
@@ -184,11 +184,11 @@ int avs_coap_ctx_send(avs_coap_ctx_t *ctx,
                       const avs_coap_msg_t *msg) {
     assert(ctx && socket);
     if (!avs_coap_msg_is_valid(msg)) {
-        LOG(ERROR, "cannot send an invalid CoAP message\n");
+        LOG(ERROR, _("cannot send an invalid CoAP message\n"));
         return -1;
     }
 
-    LOG(DEBUG, "send: %s", AVS_COAP_MSG_SUMMARY(msg));
+    LOG(DEBUG, _("send: ") "%s" , AVS_COAP_MSG_SUMMARY(msg));
     avs_error_t err = avs_net_socket_send(socket, msg->content, msg->length);
     if (avs_is_ok(err)) {
         int cache_result = try_cache_response(ctx, socket, msg);
@@ -231,7 +231,7 @@ static int try_send_cached_response(avs_coap_ctx_t *ctx,
     if (avs_is_err(avs_net_socket_get_remote_host(socket, addr, sizeof(addr)))
             || avs_is_err(avs_net_socket_get_remote_port(socket, port,
                                                          sizeof(port)))) {
-        LOG(DEBUG, "could not get remote remote host/port");
+        LOG(DEBUG, _("could not get remote remote host/port"));
         return -1;
     }
 
@@ -276,11 +276,11 @@ int avs_coap_ctx_recv(avs_coap_ctx_t *ctx,
 #endif // WITH_AVS_COAP_NET_STATS
 
     if (!avs_coap_msg_is_valid(out_msg)) {
-        LOG(DEBUG, "recv: malformed message");
+        LOG(DEBUG, _("recv: malformed message"));
         return AVS_COAP_CTX_ERR_MSG_MALFORMED;
     }
 
-    LOG(DEBUG, "recv: %s", AVS_COAP_MSG_SUMMARY(out_msg));
+    LOG(DEBUG, _("recv: ") "%s" , AVS_COAP_MSG_SUMMARY(out_msg));
 
     if (is_coap_ping(out_msg)) {
         avs_coap_ctx_send_empty(ctx, socket, AVS_COAP_MSG_RESET,
@@ -341,7 +341,7 @@ static void send_response(avs_coap_ctx_t *ctx,
     if (max_age
             && avs_coap_msg_info_opt_u32(&info, AVS_COAP_OPT_MAX_AGE,
                                          *max_age)) {
-        LOG(WARNING, "unable to add Max-Age option to response");
+        LOG(WARNING, _("unable to add Max-Age option to response"));
     }
 
     union {
@@ -355,7 +355,7 @@ static void send_response(avs_coap_ctx_t *ctx,
     assert(error);
 
     if (avs_coap_ctx_send(ctx, socket, error)) {
-        LOG(WARNING, "failed to send error message");
+        LOG(WARNING, _("failed to send error message"));
     }
 
     avs_coap_msg_info_reset(&info);

--- a/coap/src/msg.c
+++ b/coap/src/msg.c
@@ -173,20 +173,20 @@ size_t avs_coap_msg_payload_length(const avs_coap_msg_t *msg) {
 static bool is_header_valid(const avs_coap_msg_t *msg) {
     uint8_t version = _avs_coap_header_get_version(msg);
     if (version != 1) {
-        LOG(DEBUG, "unsupported CoAP version: %u", version);
+        LOG(DEBUG, _("unsupported CoAP version: ") "%u" , version);
         return false;
     }
 
     uint8_t token_length = _avs_coap_header_get_token_length(msg);
     if (token_length > AVS_COAP_MAX_TOKEN_LENGTH) {
-        LOG(DEBUG, "token too long (%dB, expected 0 <= size <= %d)",
+        LOG(DEBUG, _("token too long (") "%dB" _(", expected 0 <= size <= ") "%d" _(")"),
             token_length, AVS_COAP_MAX_TOKEN_LENGTH);
         return false;
     }
 
     size_t hdr_size = _avs_coap_header_size(msg);
     if (hdr_size + token_length > msg->length) {
-        LOG(DEBUG, "missing/incomplete token (got %u, expected %" PRIu8 ")",
+        LOG(DEBUG, _("missing/incomplete token (got ") "%u" _(", expected ") "%" PRIu8 _(")"),
             (unsigned) (msg->length - hdr_size), token_length);
         return false;
     }
@@ -207,7 +207,7 @@ static bool are_options_valid(const avs_coap_msg_t *msg) {
          avs_coap_opt_next(&optit)) {
         if (!avs_coap_opt_is_valid(optit.curr_opt,
                                    msg->length - length_so_far)) {
-            LOG(DEBUG, "option validation failed");
+            LOG(DEBUG, _("option validation failed"));
             return false;
         }
 
@@ -215,14 +215,14 @@ static bool are_options_valid(const avs_coap_msg_t *msg) {
 
         if (length_so_far > msg->length) {
             LOG(DEBUG,
-                "invalid option length (ends %lu bytes after end of message)",
+                _("invalid option length (ends ") "%lu" _(" bytes after end of message)"),
                 (unsigned long) (length_so_far - msg->length));
             return false;
         }
 
         uint32_t opt_number = avs_coap_opt_number(&optit);
         if (opt_number > UINT16_MAX) {
-            LOG(DEBUG, "invalid option number (%" PRIu32 ")", opt_number);
+            LOG(DEBUG, _("invalid option number (") "%" PRIu32 _(")"), opt_number);
             return false;
         }
     }
@@ -230,7 +230,7 @@ static bool are_options_valid(const avs_coap_msg_t *msg) {
     if (length_so_far + 1 == msg->length && is_payload_marker(optit.curr_opt)) {
         // RFC 7252 3.1: The presence of a Payload Marker followed by a
         // zero-length payload MUST be processed as a message format error.
-        LOG(DEBUG, "validation failed: payload marker at end of message");
+        LOG(DEBUG, _("validation failed: payload marker at end of message"));
         return false;
     }
 
@@ -245,7 +245,7 @@ static bool has_content_format(const avs_coap_msg_t *msg) {
 
 bool avs_coap_msg_is_valid(const avs_coap_msg_t *msg) {
     if (msg->length < AVS_COAP_MSG_MIN_SIZE) {
-        LOG(DEBUG, "message too short (%" PRIu32 "B, expected >= %" PRIu32 ")",
+        LOG(DEBUG, _("message too short (") "%" PRIu32 _("B, expected >= ") "%" PRIu32 _(")"),
             msg->length, (uint32_t) AVS_COAP_MSG_MIN_SIZE);
         return false;
     }
@@ -273,25 +273,25 @@ static const char *msg_type_string(avs_coap_msg_type_t type) {
 }
 
 void avs_coap_msg_debug_print(const avs_coap_msg_t *msg) {
-    LOG(DEBUG, "sizeof(*msg) = %lu, sizeof(len) = %lu, sizeof(header) = %lu",
+    LOG(DEBUG, _("sizeof(*msg) = ") "%lu" _(", sizeof(len) = ") "%lu" _(", sizeof(header) = ") "%lu" ,
         (unsigned long) sizeof(*msg), (unsigned long) sizeof(msg->length),
         (unsigned long) _avs_coap_header_size(msg));
-    LOG(DEBUG, "message (length = %" PRIu32 "):", msg->length);
-    LOG(DEBUG, "type: %u (%s)", avs_coap_msg_get_type(msg),
+    LOG(DEBUG, _("message (length = ") "%" PRIu32 _("):"), msg->length);
+    LOG(DEBUG, _("type: ") "%u" _(" (") "%s" _(")"), avs_coap_msg_get_type(msg),
         msg_type_string(avs_coap_msg_get_type(msg)));
 
-    LOG(DEBUG, "  version: %u", _avs_coap_header_get_version(msg));
-    LOG(DEBUG, "  token_length: %u", _avs_coap_header_get_token_length(msg));
-    LOG(DEBUG, "  code: %s", AVS_COAP_CODE_STRING(avs_coap_msg_get_code(msg)));
-    LOG(DEBUG, "  message_id: %u", avs_coap_msg_get_id(msg));
-    LOG(DEBUG, "  content:");
+    LOG(DEBUG, _("  version: ") "%u" , _avs_coap_header_get_version(msg));
+    LOG(DEBUG, _("  token_length: ") "%u" , _avs_coap_header_get_token_length(msg));
+    LOG(DEBUG, _("  code: ") "%s" , AVS_COAP_CODE_STRING(avs_coap_msg_get_code(msg)));
+    LOG(DEBUG, _("  message_id: ") "%u" , avs_coap_msg_get_id(msg));
+    LOG(DEBUG, _("  content:"));
 
     const uint8_t *content = _avs_coap_header_end_const(msg);
     for (size_t i = 0; i < msg->length - _avs_coap_header_size(msg); i += 8) {
-        LOG(DEBUG, "%02x", content[i]);
+        LOG(DEBUG,  "%02x" , content[i]);
     }
 
-    LOG(DEBUG, "opts:");
+    LOG(DEBUG, _("opts:"));
     for (avs_coap_opt_iterator_t optit = avs_coap_opt_begin(msg);
          !avs_coap_opt_end(&optit);
          avs_coap_opt_next(&optit)) {

--- a/coap/src/msg_builder.c
+++ b/coap/src/msg_builder.c
@@ -50,7 +50,7 @@ static size_t bytes_remaining(const avs_coap_msg_buffer_t *buffer) {
 static int
 append_data(avs_coap_msg_buffer_t *buffer, const void *data, size_t data_size) {
     if (data_size > bytes_remaining(buffer)) {
-        LOG(ERROR, "cannot append %u bytes, only %u available",
+        LOG(ERROR, _("cannot append ") "%u" _(" bytes, only ") "%u" _(" available"),
             (unsigned) data_size, (unsigned) bytes_remaining(buffer));
         return -1;
     }
@@ -70,13 +70,13 @@ static int append_token(avs_coap_msg_buffer_t *buffer,
 
     if (_avs_coap_header_get_code(buffer->msg) == AVS_COAP_CODE_EMPTY
             && token->size > 0) {
-        LOG(ERROR, "0.00 Empty message must not contain a token");
+        LOG(ERROR, _("0.00 Empty message must not contain a token"));
         return -1;
     }
 
     _avs_coap_header_set_token_length(buffer->msg, token->size);
     if (append_data(buffer, token->bytes, token->size)) {
-        LOG(ERROR, "could not append token");
+        LOG(ERROR, _("could not append token"));
         return -1;
     }
 
@@ -129,7 +129,7 @@ static int append_option(avs_coap_msg_buffer_t *buffer,
                          const void *opt_data,
                          uint16_t opt_data_size) {
     if (_avs_coap_header_get_code(buffer->msg) == AVS_COAP_CODE_EMPTY) {
-        LOG(ERROR, "0.00 Empty message must not contain options");
+        LOG(ERROR, _("0.00 Empty message must not contain options"));
         return -1;
     }
 
@@ -137,7 +137,7 @@ static int append_option(avs_coap_msg_buffer_t *buffer,
             _avs_coap_get_opt_header_size(opt_number_delta, opt_data_size);
 
     if (opt_header_size + opt_data_size > bytes_remaining(buffer)) {
-        LOG(ERROR, "not enough space to serialize option");
+        LOG(ERROR, _("not enough space to serialize option"));
         return -1;
     }
 
@@ -145,7 +145,7 @@ static int append_option(avs_coap_msg_buffer_t *buffer,
             msg_end_ptr(buffer), opt_number_delta, opt_data_size);
 
     if (append_data(buffer, opt_data, opt_data_size)) {
-        LOG(ERROR, "could not serialize option");
+        LOG(ERROR, _("could not serialize option"));
         return -1;
     }
 
@@ -171,7 +171,7 @@ int avs_coap_msg_builder_reset(avs_coap_msg_builder_t *builder,
                                const avs_coap_msg_info_t *info) {
     if (builder->msg_buffer.capacity
             < avs_coap_msg_info_get_headers_size(info)) {
-        LOG(ERROR, "message buffer too small: %u/%u B available",
+        LOG(ERROR, _("message buffer too small: ") "%u" _("/") "%u" _(" B available"),
             (unsigned) builder->msg_buffer.capacity,
             (unsigned) avs_coap_msg_info_get_storage_size(info));
         return -1;

--- a/coap/src/msg_cache.c
+++ b/coap/src/msg_cache.c
@@ -108,7 +108,7 @@ static endpoint_t *cache_endpoint_add_ref(coap_msg_cache_t *cache,
 
     AVS_LIST(endpoint_t) new_ep = AVS_LIST_NEW_ELEMENT(endpoint_t);
     if (!new_ep) {
-        LOG(DEBUG, "out of memory");
+        LOG(DEBUG, _("out of memory"));
         return NULL;
     }
 
@@ -119,8 +119,8 @@ static endpoint_t *cache_endpoint_add_ref(coap_msg_cache_t *cache,
                                    remote_port)
                            < 0) {
         LOG(WARNING,
-            "endpoint address or port too long: addr = %s, "
-            "port = %s",
+            _("endpoint address or port too long: addr = ") "%s" _(", ")
+            _("port = ") "%s" ,
             remote_addr, remote_port);
         AVS_LIST_DELETE(&new_ep);
         return NULL;
@@ -129,7 +129,7 @@ static endpoint_t *cache_endpoint_add_ref(coap_msg_cache_t *cache,
     new_ep->refcount = 1;
     AVS_LIST_INSERT(&cache->endpoints, new_ep);
 
-    LOG(TRACE, "added cache endpoint: %s:%s", new_ep->addr, new_ep->port);
+    LOG(TRACE, _("added cache endpoint: ") "%s" _(":") "%s" , new_ep->addr, new_ep->port);
     return new_ep;
 }
 
@@ -139,7 +139,7 @@ static void cache_endpoint_del_ref(coap_msg_cache_t *cache,
         AVS_LIST(endpoint_t) *ep_ptr =
                 (AVS_LIST(endpoint_t) *) AVS_LIST_FIND_PTR(&cache->endpoints,
                                                            endpoint);
-        LOG(TRACE, "removed cache endpoint: %s:%s", (*ep_ptr)->addr,
+        LOG(TRACE, _("removed cache endpoint: ") "%s" _(":") "%s" , (*ep_ptr)->addr,
             (*ep_ptr)->port);
         AVS_LIST_DELETE(ep_ptr);
     }
@@ -249,8 +249,8 @@ static void cache_free_bytes(coap_msg_cache_t *cache, size_t bytes_required) {
         assert(entry_valid(cache, entry));
 
         LOG(TRACE,
-            "msg_cache: dropping msg (id = %u) to make room for"
-            " a new one (size = %lu)",
+            _("msg_cache: dropping msg (id = ") "%u" _(") to make room for")
+            _(" a new one (size = ") "%lu" _(")"),
             entry_id(entry), (unsigned long) bytes_required);
         cache_endpoint_del_ref(cache, entry->endpoint);
         bytes_free += entry_size(entry);
@@ -268,7 +268,7 @@ static void cache_drop_expired(coap_msg_cache_t *cache,
     for (entry = entry_first(cache); entry_valid(cache, entry);
          entry = entry_next(entry)) {
         if (entry_expired(entry, now)) {
-            LOG(TRACE, "msg_cache: dropping expired msg (id = %u)",
+            LOG(TRACE, _("msg_cache: dropping expired msg (id = ") "%u" _(")"),
                 entry_id(entry));
             cache_endpoint_del_ref(cache, entry->endpoint);
         } else {
@@ -311,7 +311,7 @@ int _avs_coap_msg_cache_add(coap_msg_cache_t *cache,
     size_t cap_req = _avs_coap_msg_cache_overhead(msg)
                      + offsetof(avs_coap_msg_t, content) + msg->length;
     if (avs_buffer_capacity(cache->buffer) < cap_req) {
-        LOG(DEBUG, "msg_cache: not enough space for %" PRIu32 " B message",
+        LOG(DEBUG, _("msg_cache: not enough space for ") "%" PRIu32 _(" B message"),
             msg->length);
         return -1;
     }
@@ -321,7 +321,7 @@ int _avs_coap_msg_cache_add(coap_msg_cache_t *cache,
 
     uint16_t msg_id = avs_coap_msg_get_id(msg);
     if (find_entry(cache, remote_addr, remote_port, msg_id)) {
-        LOG(DEBUG, "msg_cache: message ID %u already in cache", msg_id);
+        LOG(DEBUG, _("msg_cache: message ID ") "%u" _(" already in cache"), msg_id);
         return AVS_COAP_MSG_CACHE_DUPLICATE;
     }
 
@@ -360,34 +360,34 @@ const avs_coap_msg_t *_avs_coap_msg_cache_get(coap_msg_cache_t *cache,
 
     assert(!entry_expired(entry, &now));
 
-    LOG(TRACE, "msg_cache hit (id = %u)", msg_id);
+    LOG(TRACE, _("msg_cache hit (id = ") "%u" _(")"), msg_id);
     return entry_msg(entry);
 }
 
 void _avs_coap_msg_cache_debug_print(const coap_msg_cache_t *cache) {
     if (!cache) {
-        LOG(DEBUG, "msg_cache: NULL");
+        LOG(DEBUG, _("msg_cache: NULL"));
         return;
     }
 
-    LOG(DEBUG, "msg_cache: %lu/%lu bytes used",
+    LOG(DEBUG, _("msg_cache: ") "%lu" _("/") "%lu" _(" bytes used"),
         (unsigned long) avs_buffer_data_size(cache->buffer),
         (unsigned long) avs_buffer_capacity(cache->buffer));
 
     AVS_LIST(endpoint_t) ep;
     AVS_LIST_FOREACH(ep, cache->endpoints) {
-        LOG(DEBUG, "endpoint: refcount %u, addr %s, port %s", ep->refcount,
+        LOG(DEBUG, _("endpoint: refcount ") "%u" _(", addr ") "%s" _(", port ") "%s" , ep->refcount,
             ep->addr, ep->port);
     }
 
     for (const cache_entry_t *entry = entry_first(cache);
          entry_valid(cache, entry);
          entry = entry_next(entry)) {
-        LOG(DEBUG, "entry: %p, msg padding: %lu", (const void *) entry,
+        LOG(DEBUG, _("entry: ") "%p" _(", msg padding: ") "%lu" , (const void *) entry,
             (unsigned long) padding_bytes_after_msg(entry_msg(entry)));
-        LOG(DEBUG, "endpoint: %s:%s", entry->endpoint->addr,
+        LOG(DEBUG, _("endpoint: ") "%s" _(":") "%s" , entry->endpoint->addr,
             entry->endpoint->port);
-        LOG(DEBUG, "expiration time: %" PRId64 ":%09" PRId32,
+        LOG(DEBUG, _("expiration time: ") "%" PRId64 _(":") "%09" PRId32,
             entry->expiration_time.since_monotonic_epoch.seconds,
             entry->expiration_time.since_monotonic_epoch.nanoseconds);
         avs_coap_msg_debug_print(entry_msg(entry));

--- a/coap/src/msg_info.c
+++ b/coap/src/msg_info.c
@@ -114,8 +114,8 @@ static int encode_block_size(uint16_t size, uint8_t *out_size_exponent) {
         break;
     default:
         LOG(ERROR,
-            "invalid block size: %d, expected power of 2 between 16 "
-            "and 1024 (inclusive)",
+            _("invalid block size: ") "%d" _(", expected power of 2 between 16 ")
+            _("and 1024 (inclusive)"),
             (int) size);
         return -1;
     }
@@ -135,7 +135,7 @@ static int add_block_opt(avs_coap_msg_info_t *info,
 
     AVS_STATIC_ASSERT(sizeof(int) >= sizeof(int32_t), int_type_too_small);
     if (seq_number >= (1 << 20)) {
-        LOG(ERROR, "block sequence number must be less than 2^20");
+        LOG(ERROR, _("block sequence number must be less than 2^20"));
         return -1;
     }
 
@@ -148,7 +148,7 @@ static int add_block_opt(avs_coap_msg_info_t *info,
 int avs_coap_msg_info_opt_block(avs_coap_msg_info_t *info,
                                 const avs_coap_block_info_t *block) {
     if (!block->valid) {
-        LOG(ERROR, "could not add invalid BLOCK option");
+        LOG(ERROR, _("could not add invalid BLOCK option"));
         return -1;
     }
 
@@ -164,7 +164,7 @@ int avs_coap_msg_info_opt_opaque(avs_coap_msg_info_t *info,
             (avs_coap_msg_info_opt_t *) AVS_LIST_NEW_BUFFER(sizeof(*opt)
                                                             + opt_data_size);
     if (!opt) {
-        LOG(ERROR, "out of memory");
+        LOG(ERROR, _("out of memory"));
         return -1;
     }
 

--- a/coap/src/msg_opt.c
+++ b/coap/src/msg_opt.c
@@ -57,10 +57,10 @@ int avs_coap_msg_get_option_u16(const avs_coap_msg_t *msg,
     const avs_coap_opt_t *opt;
     if (avs_coap_msg_find_unique_opt(msg, option_number, &opt)) {
         if (opt) {
-            LOG(DEBUG, "multiple instances of option %d found", option_number);
+            LOG(DEBUG, _("multiple instances of option ") "%d" _(" found"), option_number);
             return -1;
         } else {
-            LOG(TRACE, "option %d not found", option_number);
+            LOG(TRACE, _("option ") "%d" _(" not found"), option_number);
             return AVS_COAP_OPTION_MISSING;
         }
     }
@@ -73,10 +73,10 @@ int avs_coap_msg_get_option_u32(const avs_coap_msg_t *msg,
     const avs_coap_opt_t *opt;
     if (avs_coap_msg_find_unique_opt(msg, option_number, &opt)) {
         if (opt) {
-            LOG(DEBUG, "multiple instances of option %d found", option_number);
+            LOG(DEBUG, _("multiple instances of option ") "%d" _(" found"), option_number);
             return -1;
         } else {
-            LOG(TRACE, "option %d not found", option_number);
+            LOG(TRACE, _("option ") "%d" _(" not found"), option_number);
             return AVS_COAP_OPTION_MISSING;
         }
     }
@@ -157,7 +157,7 @@ int avs_coap_msg_validate_critical_options(
 
             if (!is_critical_opt_valid(code, opt_number, validator)) {
                 LOG(DEBUG,
-                    "warning: invalid critical option in query %s: %" PRIu32,
+                    _("warning: invalid critical option in query ") "%s" _(": ") "%" PRIu32,
                     AVS_COAP_CODE_STRING(avs_coap_msg_get_code(it.msg)),
                     opt_number);
                 result = -1;

--- a/coap/src/opt.c
+++ b/coap/src/opt.c
@@ -215,12 +215,12 @@ size_t avs_coap_opt_sizeof(const avs_coap_opt_t *opt) {
 }
 
 void avs_coap_opt_debug_print(const avs_coap_opt_t *opt) {
-    LOG(DEBUG, "opt: delta %" PRIu32 ", length %" PRIu32 ", content:",
+    LOG(DEBUG, _("opt: delta ") "%" PRIu32 _(", length ") "%" PRIu32 _(", content:"),
         avs_coap_opt_delta(opt), avs_coap_opt_content_length(opt));
 
     const uint8_t *value = avs_coap_opt_value(opt);
     for (size_t i = 0; i < avs_coap_opt_content_length(opt); ++i) {
-        LOG(DEBUG, "%02x", value[i]);
+        LOG(DEBUG,  "%02x" , value[i]);
     }
 }
 

--- a/coap/src/test/ctx.c
+++ b/coap/src/test/ctx.c
@@ -88,7 +88,7 @@ static void spawn_dtls_echo_server(uint16_t port) {
     server_t *serv;
     AVS_LIST_FOREACH(serv, dtls_servers) {
         if (serv->port == port) {
-            LOG(ERROR, "another server running on port %u", port);
+            LOG(ERROR, _("another server running on port ") "%u" , port);
             abort();
             return;
         }
@@ -114,14 +114,14 @@ static void spawn_dtls_echo_server(uint16_t port) {
     case 0:
 #if __linux__
         if (prctl(PR_SET_PDEATHSIG, SIGHUP)) {
-            LOG(WARNING, "prctl failed: %s", strerror(errno));
+            LOG(WARNING, _("prctl failed: ") "%s" , strerror(errno));
         }
 #endif // __linux__
         execve(cmdline[0], cmdline, NULL);
         // fall-through
     case -1:
-        LOG(ERROR, "could not start DTLS echo server: %s", strerror(errno));
-        LOG(ERROR, "command: %s %s %s %s", cmdline[0], cmdline[1], cmdline[2],
+        LOG(ERROR, _("could not start DTLS echo server: ") "%s" , strerror(errno));
+        LOG(ERROR, _("command: ") "%s" _(" ") "%s" _(" ") "%s" _(" ") "%s" , cmdline[0], cmdline[1], cmdline[2],
             cmdline[3]);
         abort();
     default:
@@ -168,7 +168,7 @@ static void udp_echo_serve(uint16_t port) {
 
     addr.sin_addr.s_addr = inet_addr("127.0.0.1");
     if (bind(sock, (struct sockaddr *) &addr, sizeof(addr))) {
-        LOG(ERROR, "UDP server (127.0.0.1:%u) bind failed: %s", port,
+        LOG(ERROR, _("UDP server (127.0.0.1:") "%u" _(") bind failed: ") "%s" , port,
             strerror(errno));
         goto cleanup;
     }
@@ -178,7 +178,7 @@ static void udp_echo_serve(uint16_t port) {
 
     while (true) {
         if (poll(&sock_pollfd, 1, -1) < 0) {
-            LOG(ERROR, "UDP server (127.0.0.1:%u) poll failed: %s", port,
+            LOG(ERROR, _("UDP server (127.0.0.1:") "%u" _(") poll failed: ") "%s" , port,
                 strerror(errno));
             goto cleanup;
         }
@@ -191,7 +191,7 @@ static void udp_echo_serve(uint16_t port) {
                 recvfrom(sock, in_buffer, sizeof(in_buffer), 0,
                          (struct sockaddr *) &remote_addr, &remote_addr_len);
         if (bytes_recv < 0) {
-            LOG(ERROR, "UDP server (127.0.0.1:%u) recvfrom failed: %s", port,
+            LOG(ERROR, _("UDP server (127.0.0.1:") "%u" _(") recvfrom failed: ") "%s" , port,
                 strerror(errno));
             goto cleanup;
         }
@@ -199,14 +199,14 @@ static void udp_echo_serve(uint16_t port) {
         ssize_t bytes_to_send = udp_echo(in_buffer, (size_t) bytes_recv,
                                          out_buffer, sizeof(out_buffer));
         if (bytes_to_send < 0) {
-            LOG(ERROR, "UDP server (127.0.0.1:%u) udp_echo failed", port);
+            LOG(ERROR, _("UDP server (127.0.0.1:") "%u" _(") udp_echo failed"), port);
             goto cleanup;
         }
 
         if (sendto(sock, out_buffer, (size_t) bytes_to_send, 0,
                    (struct sockaddr *) &remote_addr, remote_addr_len)
                 != bytes_to_send) {
-            LOG(ERROR, "UDP server (127.0.0.1:%u) sendto failed: %s", port,
+            LOG(ERROR, _("UDP server (127.0.0.1:") "%u" _(") sendto failed: ") "%s" , port,
                 strerror(errno));
             goto cleanup;
         }
@@ -214,14 +214,14 @@ static void udp_echo_serve(uint16_t port) {
 
 cleanup:
     close(sock);
-    LOG(ERROR, "UDP server (127.0.0.1:%u) shutting down", port);
+    LOG(ERROR, _("UDP server (127.0.0.1:") "%u" _(") shutting down"), port);
 }
 
 static void spawn_udp_echo_server(uint16_t port) {
     server_t *serv;
     AVS_LIST_FOREACH(serv, udp_servers) {
         if (serv->port == port) {
-            LOG(ERROR, "another server running on port %u", port);
+            LOG(ERROR, _("another server running on port ") "%u" , port);
             abort();
         }
     }
@@ -233,13 +233,13 @@ static void spawn_udp_echo_server(uint16_t port) {
     case 0:
 #if __linux__
         if (prctl(PR_SET_PDEATHSIG, SIGHUP)) {
-            LOG(WARNING, "prctl failed: %s", strerror(errno));
+            LOG(WARNING, _("prctl failed: ") "%s" , strerror(errno));
         }
 #endif // __linux__
         udp_echo_serve(port);
         // fall-through
     case -1:
-        LOG(ERROR, "could not start UDP server on port %u: %s", port,
+        LOG(ERROR, _("could not start UDP server on port ") "%u" _(": ") "%s" , port,
             strerror(errno));
         abort();
     default:

--- a/config/x_log_config.h
+++ b/config/x_log_config.h
@@ -18,6 +18,9 @@
 #    undef LOG
 #endif
 
+// enable short _() macro
+#define _(Arg) AVS_DISPOSABLE_LOG(Arg)
+
 #ifdef WITH_INTERNAL_LOGS
 
 #    ifdef WITH_INTERNAL_TRACE

--- a/crypto/src/crypto_utils.c
+++ b/crypto/src/crypto_utils.c
@@ -27,15 +27,15 @@ bool _avs_crypto_aead_parameters_valid(size_t key_len,
                                        size_t iv_len,
                                        size_t tag_len) {
     if (key_len != 16 && key_len != 32) {
-        LOG(ERROR, "invalid key length");
+        LOG(ERROR, _("invalid key length"));
         return false;
     }
     if (iv_len < 7 || iv_len > 13) {
-        LOG(ERROR, "invalid IV length");
+        LOG(ERROR, _("invalid IV length"));
         return false;
     }
     if (tag_len < 4 || tag_len > 16 || tag_len % 2 != 0) {
-        LOG(ERROR, "invalid tag length");
+        LOG(ERROR, _("invalid tag length"));
         return false;
     }
     return true;

--- a/crypto/src/mbedtls/aead.c
+++ b/crypto/src/mbedtls/aead.c
@@ -59,7 +59,7 @@ int avs_crypto_aead_aes_ccm_encrypt(const unsigned char *key,
                         output, tag, tag_len)));
     mbedtls_ccm_free(&ccm_ctx);
     if (result) {
-        LOG(ERROR, "mbed TLS error %d", result);
+        LOG(ERROR, _("mbed TLS error ") "%d" , result);
         return -1;
     }
     return 0;
@@ -98,7 +98,7 @@ int avs_crypto_aead_aes_ccm_decrypt(const unsigned char *key,
                                                   output, tag, tag_len)));
     mbedtls_ccm_free(&ccm_ctx);
     if (result) {
-        LOG(ERROR, "mbed TLS error %d", result);
+        LOG(ERROR, _("mbed TLS error ") "%d" , result);
         return -1;
     }
     return 0;

--- a/crypto/src/mbedtls/hkdf.c
+++ b/crypto/src/mbedtls/hkdf.c
@@ -50,7 +50,7 @@ int avs_crypto_hkdf_sha_256(const unsigned char *salt,
     int result = mbedtls_hkdf(md, salt, salt_len, ikm, ikm_len, info, info_len,
                               out_okm, *inout_okm_len);
     if (result) {
-        LOG(ERROR, "mbed TLS error %d", result);
+        LOG(ERROR, _("mbed TLS error ") "%d" , result);
         return -1;
     }
     return 0;

--- a/http/src/auth.c
+++ b/http/src/auth.c
@@ -57,14 +57,14 @@ static char *consume_alloc_quotable_token(const char **src) {
 int _avs_http_auth_setup(http_auth_t *auth, const char *challenge) {
     http_auth_new_header(auth);
     if (avs_match_token(&challenge, "Basic", AVS_SPACES) == 0) {
-        LOG(TRACE, "Basic authentication");
+        LOG(TRACE, _("Basic authentication"));
         auth->state.flags.type = HTTP_AUTH_TYPE_BASIC;
     } else if (avs_match_token(&challenge, "Digest", AVS_SPACES) == 0) {
-        LOG(TRACE, "Digest authentication");
+        LOG(TRACE, _("Digest authentication"));
         auth->state.flags.type = HTTP_AUTH_TYPE_DIGEST;
     } else {
         /* unknown scheme, ignore */
-        LOG(WARNING, "No authentication");
+        LOG(WARNING, _("No authentication"));
         return 0;
     }
 
@@ -73,44 +73,44 @@ int _avs_http_auth_setup(http_auth_t *auth, const char *challenge) {
             avs_free(auth->state.realm);
             if (!(auth->state.realm =
                           consume_alloc_quotable_token(&challenge))) {
-                LOG(ERROR, "Could not allocate memory for auth realm");
+                LOG(ERROR, _("Could not allocate memory for auth realm"));
                 return -1;
             }
-            LOG(TRACE, "Auth realm: %s", auth->state.realm);
+            LOG(TRACE, _("Auth realm: ") "%s" , auth->state.realm);
         } else if (avs_match_token(&challenge, "nonce", "=") == 0) {
             avs_free(auth->state.nonce);
             if (!(auth->state.nonce =
                           consume_alloc_quotable_token(&challenge))) {
-                LOG(ERROR, "Could not allocate memory for auth nonce");
+                LOG(ERROR, _("Could not allocate memory for auth nonce"));
                 return -1;
             }
             auth->state.nc = 1;
-            LOG(TRACE, "Auth nonce: %s", auth->state.nonce);
+            LOG(TRACE, _("Auth nonce: ") "%s" , auth->state.nonce);
         } else if (avs_match_token(&challenge, "opaque", "=") == 0) {
             avs_free(auth->state.opaque);
             if (!(auth->state.opaque =
                           consume_alloc_quotable_token(&challenge))) {
-                LOG(ERROR, "Could not allocate memory for auth opaque");
+                LOG(ERROR, _("Could not allocate memory for auth opaque"));
                 return -1;
             }
-            LOG(TRACE, "Auth opaque: %s", auth->state.opaque);
+            LOG(TRACE, _("Auth opaque: ") "%s" , auth->state.opaque);
         } else if (avs_match_token(&challenge, "algorithm", "=") == 0) {
             char algorithm[16];
             avs_consume_quotable_token(&challenge, algorithm, sizeof(algorithm),
                                        "," AVS_SPACES);
             if (avs_strcasecmp(algorithm, "MD5-sess") == 0) {
                 auth->state.flags.use_md5_sess = 1;
-                LOG(TRACE, "Auth algorithm: MD5-sess");
+                LOG(TRACE, _("Auth algorithm: MD5-sess"));
             } else if (avs_strcasecmp(algorithm, "MD5") == 0) {
-                LOG(TRACE, "Auth algorithm: MD5");
+                LOG(TRACE, _("Auth algorithm: MD5"));
             } else {
-                LOG(ERROR, "Unknown auth algorithm: %s", algorithm);
+                LOG(ERROR, _("Unknown auth algorithm: ") "%s" , algorithm);
                 return -1;
             }
         } else if (avs_match_token(&challenge, "qop", "=") == 0) {
             char *qop_options_buf = consume_alloc_quotable_token(&challenge);
             if (!qop_options_buf) {
-                LOG(ERROR, "Could not allocate memory for qop");
+                LOG(ERROR, _("Could not allocate memory for qop"));
                 return -1;
             }
             char *qop_options_tmp, *qop_options = qop_options_buf;
@@ -118,7 +118,7 @@ int _avs_http_auth_setup(http_auth_t *auth, const char *challenge) {
             while ((qop_option = avs_strtok(qop_options, "," AVS_SPACES,
                                             &qop_options_tmp))) {
                 qop_options = NULL;
-                LOG(TRACE, "Auth qop: %s", qop_option);
+                LOG(TRACE, _("Auth qop: ") "%s" , qop_option);
                 if (avs_strcasecmp(qop_option, "auth") == 0) {
                     auth->state.flags.use_qop_auth = 1;
                     break;
@@ -127,7 +127,7 @@ int _avs_http_auth_setup(http_auth_t *auth, const char *challenge) {
             avs_free(qop_options_buf);
             if (!auth->state.flags.use_qop_auth) {
                 LOG(ERROR,
-                    "qop option present, but qop=\"auth\" not supported");
+                    _("qop option present, but qop=\"auth\" not supported"));
                 return -1;
             }
         } else {
@@ -138,22 +138,22 @@ int _avs_http_auth_setup(http_auth_t *auth, const char *challenge) {
 }
 
 avs_error_t _avs_http_auth_send_header(http_stream_t *stream) {
-    LOG(TRACE, "http_send_auth_header");
+    LOG(TRACE, _("http_send_auth_header"));
     switch (stream->auth.state.flags.type) {
     case HTTP_AUTH_TYPE_NONE:
-        LOG(TRACE, "HTTP_AUTH_NONE");
+        LOG(TRACE, _("HTTP_AUTH_NONE"));
         return AVS_OK;
 
     case HTTP_AUTH_TYPE_BASIC:
-        LOG(TRACE, "HTTP_AUTH_BASIC");
+        LOG(TRACE, _("HTTP_AUTH_BASIC"));
         return _avs_http_auth_send_header_basic(stream);
 
     case HTTP_AUTH_TYPE_DIGEST:
-        LOG(TRACE, "HTTP_AUTH_DIGEST");
+        LOG(TRACE, _("HTTP_AUTH_DIGEST"));
         return _avs_http_auth_send_header_digest(stream);
 
     default:
-        LOG(ERROR, "unknown auth type %d", (int) stream->auth.state.flags.type);
+        LOG(ERROR, _("unknown auth type ") "%d" , (int) stream->auth.state.flags.type);
         return avs_errno(AVS_EPROTO);
     }
 }

--- a/http/src/auth/basic.c
+++ b/http/src/auth/basic.c
@@ -39,7 +39,7 @@ avs_error_t _avs_http_auth_send_header_basic(http_stream_t *stream) {
     size_t encoded_size = avs_base64_encoded_size(plaintext_size - 1);
     char *buffer = (char *) avs_malloc(plaintext_size + encoded_size);
     if (!buffer) {
-        LOG(ERROR, "Out of memory");
+        LOG(ERROR, _("Out of memory"));
         return avs_errno(AVS_ENOMEM);
     }
     char *plaintext = buffer;
@@ -63,7 +63,7 @@ avs_error_t _avs_http_auth_send_header_basic(http_stream_t *stream) {
         AVS_UNREACHABLE("Cannot encode authorization data");
         err = avs_errno(AVS_UNKNOWN_ERROR);
     } else {
-        LOG(TRACE, "Basic encoded pass: %s", encoded);
+        LOG(TRACE, _("Basic encoded pass: ") "%s" , encoded);
         err = avs_stream_write_f(stream->backend, "Authorization: Basic %s\r\n",
                                  encoded);
     }

--- a/http/src/auth/digest.c
+++ b/http/src/auth/digest.c
@@ -198,10 +198,10 @@ avs_error_t _avs_http_auth_send_header_digest(http_stream_t *stream) {
             || avs_is_err((err = avs_stream_write_f(stream->backend, "\r\n"))));
 auth_digest_error:
     if (avs_is_err((stream_cleanup_err = avs_stream_cleanup(&md5)))) {
-        LOG(ERROR, "failed to close MD5 stream");
+        LOG(ERROR, _("failed to close MD5 stream"));
     }
     if (avs_is_err(err)) {
-        LOG(ERROR, "error calculating digest auth md5");
+        LOG(ERROR, _("error calculating digest auth md5"));
         return err;
     }
     return stream_cleanup_err;

--- a/http/src/body_receivers.c
+++ b/http/src/body_receivers.c
@@ -36,8 +36,8 @@ create_body_receiver(avs_stream_t *backend,
     avs_stream_t *retval = NULL;
     avs_net_socket_t *backend_socket = NULL;
     LOG(TRACE,
-        "create_body_receiver, transfer_encoding == %d, "
-        "content_length == %lu",
+        _("create_body_receiver, transfer_encoding == ") "%d" _(", ")
+        _("content_length == ") "%lu" ,
         (int) transfer_encoding, (unsigned long) content_length);
 
     if (backend && (backend_socket = avs_stream_net_getsock(backend))) {
@@ -45,12 +45,12 @@ create_body_receiver(avs_stream_t *backend,
                                  buffer_sizes->body_recv, 0);
     }
     if (!buffer) {
-        LOG(ERROR, "could not create buffered netstream");
+        LOG(ERROR, _("could not create buffered netstream"));
         return NULL;
     }
 
     if (avs_stream_netbuf_transfer(buffer, backend)) {
-        LOG(ERROR, "could not transfer buffered data");
+        LOG(ERROR, _("could not transfer buffered data"));
         goto create_body_receiver_return;
     }
 
@@ -71,7 +71,7 @@ create_body_receiver(avs_stream_t *backend,
 
 create_body_receiver_return:
     if (!retval) {
-        LOG(ERROR, "could not create body receiver");
+        LOG(ERROR, _("could not create body receiver"));
         avs_stream_net_setsock(buffer, NULL); /* don't close the socket */
         avs_stream_cleanup(&buffer);
     }
@@ -85,13 +85,13 @@ int _avs_http_body_receiver_init(http_stream_t *stream,
     avs_stream_t *decoder = NULL;
     int result = 0;
     LOG(TRACE,
-        "http_init_body_receiver, transfer_encoding == %d, "
-        "content_encoding == %d, content_length == %lu, HTTP status == %d",
+        _("http_init_body_receiver, transfer_encoding == ") "%d" _(", ")
+        _("content_encoding == ") "%d" _(", content_length == ") "%lu" _(", HTTP status == ") "%d" ,
         (int) transfer_encoding, (int) content_encoding,
         (unsigned long) content_length, stream->status);
 
     if (stream->body_receiver) {
-        LOG(ERROR, "body receiver already present");
+        LOG(ERROR, _("body receiver already present"));
         return -1;
     }
 

--- a/http/src/body_receivers/chunked_body_receiver.c
+++ b/http/src/body_receivers/chunked_body_receiver.c
@@ -46,26 +46,26 @@ static avs_error_t read_chunk_size(const avs_http_buffer_sizes_t *buffer_sizes,
                                    size_t *out_value) {
     char *line_buf = (char *) avs_malloc(buffer_sizes->header_line);
     if (!line_buf) {
-        LOG(ERROR, "Out of memory");
+        LOG(ERROR, _("Out of memory"));
         return avs_errno(AVS_ENOMEM);
     }
     unsigned long value = 0;
     avs_error_t err;
-    LOG(TRACE, "read_chunk_size");
+    LOG(TRACE, _("read_chunk_size"));
     while (true) {
         char *endptr = NULL;
         err = getline_func(getline_func_state, line_buf,
                            buffer_sizes->header_line);
         if (avs_is_err(err)) {
             if (avs_is_eof(err)) {
-                LOG(ERROR, "unexpected end of stream");
+                LOG(ERROR, _("unexpected end of stream"));
                 err = avs_errno(AVS_EPROTO);
             } else {
-                LOG(ERROR, "error reading chunk headline");
+                LOG(ERROR, _("error reading chunk headline"));
             }
             break;
         }
-        LOG(TRACE, "chunk headline: %s", line_buf);
+        LOG(TRACE, _("chunk headline: ") "%s" , line_buf);
         if (!line_buf[0]) { /* empty string */
             continue;
         }
@@ -73,7 +73,7 @@ static avs_error_t read_chunk_size(const avs_http_buffer_sizes_t *buffer_sizes,
         value = strtoul(line_buf, &endptr, 16);
         if (errno) {
             err = avs_errno(avs_map_errno(errno));
-            LOG(ERROR, "invalid chunk headline");
+            LOG(ERROR, _("invalid chunk headline"));
             break;
         }
         if (*endptr == '\0' || *endptr == ';') { /* entire line read */
@@ -89,7 +89,7 @@ static avs_error_t read_chunk_size(const avs_http_buffer_sizes_t *buffer_sizes,
             if (avs_is_err(err) || !line_buf[0]) {
                 break;
             }
-            LOG(TRACE, "ignoring trailer: %s", line_buf);
+            LOG(TRACE, _("ignoring trailer: ") "%s" , line_buf);
         }
     }
     avs_free(line_buf);
@@ -139,7 +139,7 @@ static avs_error_t chunked_read(avs_stream_t *stream_,
                           AVS_MIN(buffer_length, stream->chunk_left));
     stream->chunk_left -= *out_bytes_read;
     if (avs_is_ok(err) && backend_message_finished) {
-        LOG(ERROR, "unexpected end of stream");
+        LOG(ERROR, _("unexpected end of stream"));
         return avs_errno(AVS_EIO);
     }
     if (out_message_finished) {
@@ -224,7 +224,7 @@ avs_stream_t *_avs_http_body_receiver_chunked_create(
         avs_stream_t *backend, const avs_http_buffer_sizes_t *buffer_sizes) {
     chunked_receiver_t *retval =
             (chunked_receiver_t *) avs_calloc(1, sizeof(*retval));
-    LOG(TRACE, "create_content_length_receiver");
+    LOG(TRACE, _("create_content_length_receiver"));
     if (retval) {
         *(const avs_stream_v_table_t **) (intptr_t) &retval->vtable =
                 &chunked_receiver_vtable;

--- a/http/src/body_receivers/content_length.c
+++ b/http/src/body_receivers/content_length.c
@@ -52,7 +52,7 @@ static avs_error_t content_length_read(avs_stream_t *stream_,
     }
     if (avs_is_ok(err) && backend_message_finished
             && stream->content_left > 0) {
-        LOG(ERROR, "remote connection closed unexpectedly");
+        LOG(ERROR, _("remote connection closed unexpectedly"));
         err = avs_errno(AVS_EIO);
     }
     if (out_message_finished) {
@@ -105,7 +105,7 @@ _avs_http_body_receiver_content_length_create(avs_stream_t *backend,
                                               size_t content_length) {
     content_length_receiver_t *retval =
             (content_length_receiver_t *) avs_malloc(sizeof(*retval));
-    LOG(TRACE, "create_content_length_receiver");
+    LOG(TRACE, _("create_content_length_receiver"));
     if (retval) {
         *(const avs_stream_v_table_t **) (intptr_t) &retval->vtable =
                 &content_length_receiver_vtable;

--- a/http/src/body_receivers/dumb_body_receiver.c
+++ b/http/src/body_receivers/dumb_body_receiver.c
@@ -74,7 +74,7 @@ static const avs_stream_v_table_t dumb_body_receiver_vtable = {
 avs_stream_t *_avs_http_body_receiver_dumb_create(avs_stream_t *backend) {
     dumb_proxy_receiver_t *retval =
             (dumb_proxy_receiver_t *) avs_malloc(sizeof(*retval));
-    LOG(TRACE, "create_dumb_body_receiver");
+    LOG(TRACE, _("create_dumb_body_receiver"));
     if (retval) {
         *(const avs_stream_v_table_t **) (intptr_t) &retval->vtable =
                 &dumb_body_receiver_vtable;

--- a/http/src/chunked.c
+++ b/http/src/chunked.c
@@ -32,7 +32,7 @@ static avs_error_t http_send_single_chunk(http_stream_t *stream,
                                           size_t buffer_length) {
     char size_buf[sizeof(unsigned long) * 2 + 3];
     avs_error_t err;
-    LOG(TRACE, "http_send_single_chunk, buffer_length == %lu",
+    LOG(TRACE, _("http_send_single_chunk, buffer_length == ") "%lu" ,
         (unsigned long) buffer_length);
     if (avs_simple_snprintf(size_buf, sizeof(size_buf), "%lX\r\n",
                             (unsigned long) buffer_length)
@@ -53,7 +53,7 @@ avs_error_t _avs_http_chunked_send_first(http_stream_t *stream,
                                          const void *data,
                                          size_t data_length) {
     avs_error_t err;
-    LOG(TRACE, "http_chunked_send_first");
+    LOG(TRACE, _("http_chunked_send_first"));
     stream->flags.chunked_sending = 1;
     stream->auth.state.flags.retried = 0;
     do {

--- a/http/src/client.c
+++ b/http/src/client.c
@@ -43,7 +43,7 @@ const char *const _AVS_HTTP_METHOD_NAMES[] = { "GET", "POST", "PUT" };
 avs_http_t *avs_http_new(const avs_http_buffer_sizes_t *buffer_sizes) {
     avs_http_t *result = (avs_http_t *) avs_calloc(1, sizeof(avs_http_t));
     if (!result) {
-        LOG(ERROR, "Out of memory");
+        LOG(ERROR, _("Out of memory"));
         return NULL;
     }
     result->buffer_sizes = *buffer_sizes;
@@ -74,7 +74,7 @@ int avs_http_set_user_agent(avs_http_t *http, const char *user_agent) {
     char *new_user_agent = NULL;
     if (user_agent) {
         if (!(new_user_agent = avs_strdup(user_agent))) {
-            LOG(ERROR, "Out of memory");
+            LOG(ERROR, _("Out of memory"));
             return -1;
         }
     }
@@ -93,9 +93,9 @@ int _avs_http_set_cookie(avs_http_t *client,
                          const char *cookie_header) {
     const char *equal_sign = strchr(cookie_header, '=');
     const char *end = strchr(cookie_header, ';');
-    LOG(TRACE, "Set-Cookie%s: %s", use_cookie2 ? "2" : "", cookie_header);
+    LOG(TRACE, _("Set-Cookie") "%s" _(": ") "%s" , use_cookie2 ? "2" : "", cookie_header);
     if (!equal_sign) {
-        LOG(ERROR, "Invalid cookie format: %s", cookie_header);
+        LOG(ERROR, _("Invalid cookie format: ") "%s" , cookie_header);
         return -1;
     }
     if (!end) { /* no semicolon; read to the end */
@@ -116,7 +116,7 @@ int _avs_http_set_cookie(avs_http_t *client,
 
     if (!AVS_LIST_INSERT(it, (AVS_LIST(http_cookie_t)) AVS_LIST_NEW_BUFFER(
                                      (size_t) ((end - cookie_header) + 1)))) {
-        LOG(ERROR, "Not enough space to store the cookie");
+        LOG(ERROR, _("Not enough space to store the cookie"));
         return -1;
     }
     memcpy((*it)->value, cookie_header, (size_t) (end - cookie_header));

--- a/http/src/content_encoding.c
+++ b/http/src/content_encoding.c
@@ -158,10 +158,10 @@ static avs_error_t decoding_close(avs_stream_t *stream_) {
     decoding_stream_t *stream = (decoding_stream_t *) stream_;
     avs_error_t decoder_err, backend_err;
     if (avs_is_err((decoder_err = avs_stream_cleanup(&stream->decoder)))) {
-        LOG(ERROR, "failed to close decoder stream");
+        LOG(ERROR, _("failed to close decoder stream"));
     }
     if (avs_is_err((backend_err = avs_stream_cleanup(&stream->backend)))) {
-        LOG(ERROR, "failed to close backend stream");
+        LOG(ERROR, _("failed to close backend stream"));
     }
     return avs_is_ok(decoder_err) ? backend_err : decoder_err;
 }
@@ -187,7 +187,7 @@ _avs_http_decoding_stream_create(avs_stream_t *backend,
                                  const avs_http_buffer_sizes_t *buffer_sizes) {
     decoding_stream_t *retval =
             (decoding_stream_t *) avs_malloc(sizeof(*retval));
-    LOG(TRACE, "create_decoding_stream");
+    LOG(TRACE, _("create_decoding_stream"));
     if (retval) {
         *(const avs_stream_v_table_t **) (intptr_t) &retval->vtable =
                 &decoding_vtable;
@@ -216,7 +216,7 @@ int _avs_http_content_decoder_create(
         return *out_decoder ? 0 : -1;
 
     case AVS_HTTP_CONTENT_COMPRESS:
-        LOG(ERROR, "'compress' content encoding is not supported");
+        LOG(ERROR, _("'compress' content encoding is not supported"));
         return -1;
 
     case AVS_HTTP_CONTENT_DEFLATE:
@@ -227,7 +227,7 @@ int _avs_http_content_decoder_create(
         return *out_decoder ? 0 : -1;
 
     default:
-        LOG(ERROR, "Unknown content encoding");
+        LOG(ERROR, _("Unknown content encoding"));
         return -1;
     }
 }

--- a/http/src/headers_send.c
+++ b/http/src/headers_send.c
@@ -54,7 +54,7 @@ static avs_error_t send_common_headers(avs_stream_t *stream,
 avs_error_t _avs_http_send_headers(http_stream_t *stream,
                                    size_t content_length) {
     stream->status = 0;
-    LOG(TRACE, "http_send_headers");
+    LOG(TRACE, _("http_send_headers"));
     avs_error_t err;
     if (avs_is_err((err = send_common_headers(stream->backend, stream->method,
                                               avs_url_host(stream->url),
@@ -137,7 +137,7 @@ avs_error_t _avs_http_send_headers(http_stream_t *stream,
                                      "Content-Encoding: gzip\r\n");
             break;
         case AVS_HTTP_CONTENT_COMPRESS:
-            LOG(ERROR, "'compress' content encoding is not supported");
+            LOG(ERROR, _("'compress' content encoding is not supported"));
             err = avs_errno(AVS_ENOTSUP);
             break;
         case AVS_HTTP_CONTENT_DEFLATE:
@@ -145,7 +145,7 @@ avs_error_t _avs_http_send_headers(http_stream_t *stream,
                                      "Content-Encoding: deflate\r\n");
             break;
         default:
-            LOG(ERROR, "Unknown content encoding");
+            LOG(ERROR, _("Unknown content encoding"));
             err = avs_errno(AVS_ENOTSUP);
         }
         if (avs_is_err(err)) {
@@ -155,7 +155,7 @@ avs_error_t _avs_http_send_headers(http_stream_t *stream,
 #endif
     if (avs_is_ok((err = avs_stream_write(stream->backend, "\r\n", 2)))
             && avs_is_ok((err = avs_stream_finish_message(stream->backend)))) {
-        LOG(TRACE, "http_send_headers: success");
+        LOG(TRACE, _("http_send_headers: success"));
     }
     return err;
 }

--- a/http/src/zlib.c
+++ b/http/src/zlib.c
@@ -78,7 +78,7 @@ static avs_error_t compressor_flush(zlib_stream_t *stream) {
     }
     if (stream->error != Z_OK && stream->error != Z_STREAM_END) {
         avs_error_t err = map_zlib_error(stream->error);
-        LOG(ERROR, "Compression error (%d): %s", stream->error,
+        LOG(ERROR, _("Compression error (") "%d" _("): ") "%s" , stream->error,
             get_zlib_msg(stream));
         return err;
     }
@@ -102,7 +102,7 @@ static avs_error_t decompressor_flush(zlib_stream_t *stream) {
     }
     if (stream->error != Z_OK && stream->error != Z_STREAM_END) {
         avs_error_t err = map_zlib_error(stream->error);
-        LOG(ERROR, "Decompression error (%d): %s", stream->error,
+        LOG(ERROR, _("Decompression error (") "%d" _("): ") "%s" , stream->error,
             get_zlib_msg(stream));
         return err;
     }
@@ -121,7 +121,7 @@ static avs_error_t zlib_stream_write_some(avs_stream_t *stream_,
                                           size_t *inout_data_length) {
     zlib_stream_t *stream = (zlib_stream_t *) stream_;
     if (stream->error == Z_STREAM_END || stream->flush != Z_NO_FLUSH) {
-        LOG(ERROR, "Stream finished");
+        LOG(ERROR, _("Stream finished"));
         return avs_errno(AVS_EBADF);
     }
     if (*inout_data_length
@@ -192,7 +192,7 @@ static avs_error_t zlib_stream_read(avs_stream_t *stream_,
         }
     } else if (stream->error != Z_OK) {
         avs_error_t err = map_zlib_error(stream->error);
-        LOG(ERROR, "zlib operation error (%d): %s", stream->error,
+        LOG(ERROR, _("zlib operation error (") "%d" _("): ") "%s" , stream->error,
             get_zlib_msg(stream));
         return err;
     }
@@ -215,7 +215,7 @@ static avs_error_t zlib_stream_peek(avs_stream_t *stream_,
                                     char *out_value) {
     zlib_stream_t *stream = (zlib_stream_t *) stream_;
     if (offset > stream->output_buffer_size) {
-        LOG(ERROR, "cannot peek - buffer is too small");
+        LOG(ERROR, _("cannot peek - buffer is too small"));
         return avs_errno(AVS_ENOBUFS);
     }
     if (stream->zlib.avail_out + offset >= stream->output_buffer_size) {
@@ -255,13 +255,13 @@ static zlib_stream_t *zlib_stream_init(const avs_stream_v_table_t *vtable,
                                        size_t input_buffer_size,
                                        size_t output_buffer_size) {
     if (input_buffer_size <= 0 || output_buffer_size <= 0) {
-        LOG(ERROR, "buffers cannot be zero-length");
+        LOG(ERROR, _("buffers cannot be zero-length"));
         return NULL;
     }
     zlib_stream_t *stream = (zlib_stream_t *) avs_calloc(
             1, sizeof(zlib_stream_t) + input_buffer_size + output_buffer_size);
     if (!stream) {
-        LOG(ERROR, "cannot allocate memory");
+        LOG(ERROR, _("cannot allocate memory"));
         return NULL;
     }
     *(const avs_stream_v_table_t **) (intptr_t) &stream->vtable = vtable;
@@ -323,7 +323,7 @@ avs_stream_t *_avs_http_create_compressor(http_compression_format_t format,
                                   + (format == HTTP_COMPRESSION_GZIP ? 16 : 0),
                           mem_level, Z_DEFAULT_STRATEGY);
     if (result != Z_OK) {
-        LOG(ERROR, "could not initialize zlib (%d): %s", result,
+        LOG(ERROR, _("could not initialize zlib (") "%d" _("): ") "%s" , result,
             get_zlib_msg(stream));
         avs_free(stream);
         return NULL;
@@ -372,7 +372,7 @@ avs_stream_t *_avs_http_create_decompressor(http_compression_format_t format,
                           window_bits
                                   + (format == HTTP_COMPRESSION_GZIP ? 16 : 0));
     if (result != Z_OK) {
-        LOG(ERROR, "could not initialize zlib (%d): %s", result,
+        LOG(ERROR, _("could not initialize zlib (") "%d" _("): ") "%s" , result,
             get_zlib_msg(stream));
         avs_free(stream);
         return NULL;

--- a/include_public/avsystem/commons/defs.h.in
+++ b/include_public/avsystem/commons/defs.h.in
@@ -36,6 +36,8 @@ extern "C" {
 #cmakedefine WITH_IPV4
 /** Is the library compiled with IPv6 support? */
 #cmakedefine WITH_IPV6
+/** Is the library compiled with micro logs feature? */
+#cmakedefine WITH_AVS_MICRO_LOGS
 
 #ifdef WITH_IPV6
 #    define AVS_ADDRSTRLEN \

--- a/log/include_public/avsystem/commons/log.h
+++ b/log/include_public/avsystem/commons/log.h
@@ -148,6 +148,12 @@ void avs_log_internal_l__(avs_log_level_t level,
                           const char *msg,
                           ...) AVS_F_PRINTF(5, 6);
 
+#ifndef WITH_AVS_MICRO_LOGS
+#    define AVS_DISPOSABLE_LOG(Arg) Arg
+#else
+#    define AVS_DISPOSABLE_LOG(Arg) " "
+#endif // WITH_AVS_MICRO_LOGS
+
 #define AVS_LOG_IMPL__(Level, Variant, ModuleStr, ...)                   \
     avs_log_internal_##Variant##__(Level, ModuleStr, __FILE__, __LINE__, \
                                    __VA_ARGS__)

--- a/log/src/test/test_log.c
+++ b/log/src/test/test_log.c
@@ -70,18 +70,18 @@ AVS_UNIT_TEST(log, initial) {
     /* plain */
     ASSERT_LOG(test,
                INFO,
-               "INFO [test] [" __FILE__ ":%d]: Hello, world!",
+               _("INFO [test] [") __FILE__ _(":") "%d" _("]: Hello, world!"),
                __LINE__ + 1);
-    avs_log(test, INFO, "Hello, world!");
+    avs_log(test, INFO, _("Hello, world!"));
 
     /* formatted */
     ASSERT_LOG(test,
                ERROR,
-               "ERROR [test] [" __FILE__ ":%d]: Hello, world!",
+               _("ERROR [test] [") __FILE__ _(":") "%d" _("]: Hello, world!"),
                __LINE__ + 1);
-    avs_log(test, ERROR, "%s, %s!", "Hello", "world");
+    avs_log(test, ERROR,  "%s" _(", ") "%s" _("!"), "Hello", "world");
 
-    avs_log(test, DEBUG, "Not printed");
+    avs_log(test, DEBUG, _("Not printed"));
 
     ASSERT_LOG_CLEAN;
     reset_everything();
@@ -92,72 +92,72 @@ AVS_UNIT_TEST(log, default_level) {
     avs_log_set_default_level(AVS_LOG_DEBUG);
     ASSERT_LOG(test,
                DEBUG,
-               "DEBUG [test] [" __FILE__ ":%d]: Testing DEBUG",
+               _("DEBUG [test] [") __FILE__ _(":") "%d" _("]: Testing DEBUG"),
                __LINE__ + 1);
-    avs_log(test, DEBUG, "Testing DEBUG");
+    avs_log(test, DEBUG, _("Testing DEBUG"));
     ASSERT_LOG(test,
                INFO,
-               "INFO [test] [" __FILE__ ":%d]: Testing INFO",
+               _("INFO [test] [") __FILE__ _(":") "%d" _("]: Testing INFO"),
                __LINE__ + 1);
-    avs_log(test, INFO, "Testing INFO");
+    avs_log(test, INFO, _("Testing INFO"));
     ASSERT_LOG(test,
                WARNING,
-               "WARNING [test] [" __FILE__ ":%d]: Testing WARNING",
+               _("WARNING [test] [") __FILE__ _(":") "%d" _("]: Testing WARNING"),
                __LINE__ + 1);
-    avs_log(test, WARNING, "Testing WARNING");
+    avs_log(test, WARNING, _("Testing WARNING"));
     ASSERT_LOG(test,
                ERROR,
-               "ERROR [test] [" __FILE__ ":%d]: Testing ERROR",
+               _("ERROR [test] [") __FILE__ _(":") "%d" _("]: Testing ERROR"),
                __LINE__ + 1);
-    avs_log(test, ERROR, "Testing ERROR");
+    avs_log(test, ERROR, _("Testing ERROR"));
 
     avs_log_set_default_level(AVS_LOG_INFO);
-    avs_log(test, DEBUG, "Testing DEBUG");
+    avs_log(test, DEBUG, _("Testing DEBUG"));
     ASSERT_LOG(test,
                INFO,
-               "INFO [test] [" __FILE__ ":%d]: Testing INFO",
+               _("INFO [test] [") __FILE__ _(":") "%d" _("]: Testing INFO"),
                __LINE__ + 1);
-    avs_log(test, INFO, "Testing INFO");
+    avs_log(test, INFO, _("Testing INFO"));
     ASSERT_LOG(test,
                WARNING,
-               "WARNING [test] [" __FILE__ ":%d]: Testing WARNING",
+               _("WARNING [test] [") __FILE__ _(":") "%d" _("]: Testing WARNING"),
                __LINE__ + 1);
-    avs_log(test, WARNING, "Testing WARNING");
+    avs_log(test, WARNING, _("Testing WARNING"));
     ASSERT_LOG(test,
                ERROR,
-               "ERROR [test] [" __FILE__ ":%d]: Testing ERROR",
+               _("ERROR [test] [") __FILE__ _(":") "%d" _("]: Testing ERROR"),
                __LINE__ + 1);
-    avs_log(test, ERROR, "Testing ERROR");
+    avs_log(test, ERROR, _("Testing ERROR"));
 
     avs_log_set_default_level(AVS_LOG_WARNING);
-    avs_log(test, DEBUG, "Testing DEBUG");
-    avs_log(test, INFO, "Testing INFO");
+    avs_log(test, DEBUG, _("Testing DEBUG"));
+    avs_log(test, INFO, _("Testing INFO"));
     ASSERT_LOG(test,
                WARNING,
-               "WARNING [test] [" __FILE__ ":%d]: Testing WARNING",
+               _("WARNING [test] [") __FILE__ _(":") "%d" _("]: Testing WARNING"),
                __LINE__ + 1);
-    avs_log(test, WARNING, "Testing WARNING");
+    avs_log(test, WARNING, _("Testing WARNING"));
     ASSERT_LOG(test,
                ERROR,
-               "ERROR [test] [" __FILE__ ":%d]: Testing ERROR",
+               _("ERROR [test] [") __FILE__ _(":") "%d" _("]: Testing ERROR"),
                __LINE__ + 1);
-    avs_log(test, ERROR, "Testing ERROR");
+    avs_log(test, ERROR, _("Testing ERROR"));
 
     avs_log_set_default_level(AVS_LOG_ERROR);
-    avs_log(test, DEBUG, "Testing DEBUG");
-    avs_log(test, INFO, "Testing INFO");
-    avs_log(test, WARNING, "Testing WARNING");
+    avs_log(test, DEBUG, _("Testing DEBUG"));
+    avs_log(test, INFO, _("Testing INFO"));
+    avs_log(test, WARNING, _("Testing WARNING"));
     ASSERT_LOG(test,
                ERROR,
-               "ERROR [test] [" __FILE__ ":%d]: Testing ERROR",
+               _("ERROR [test] [") __FILE__ _(":") "%d" _("]: Testing ERROR"),
                __LINE__ + 1);
-    avs_log(test, ERROR, "Testing ERROR");
+    avs_log(test, ERROR, _("Testing ERROR"));
 
     avs_log_set_default_level(AVS_LOG_QUIET);
-    avs_log(test, DEBUG, "Testing DEBUG");
-    avs_log(test, INFO, "Testing INFO");
-    avs_log(test, WARNING, "Testing WARNING");
-    avs_log(test, ERROR, "Testing ERROR");
+    avs_log(test, DEBUG, _("Testing DEBUG"));
+    avs_log(test, INFO, _("Testing INFO"));
+    avs_log(test, WARNING, _("Testing WARNING"));
+    avs_log(test, ERROR, _("Testing ERROR"));
 
     ASSERT_LOG_CLEAN;
     reset_everything();
@@ -169,51 +169,51 @@ AVS_UNIT_TEST(log, module_levels) {
 
     ASSERT_LOG(debugged_module,
                DEBUG,
-               "DEBUG [debugged_module] [" __FILE__ ":%d]: Testing DEBUG",
+               _("DEBUG [debugged_module] [") __FILE__ _(":") "%d" _("]: Testing DEBUG"),
                __LINE__ + 1);
-    avs_log(debugged_module, DEBUG, "Testing DEBUG");
+    avs_log(debugged_module, DEBUG, _("Testing DEBUG"));
     ASSERT_LOG(debugged_module,
                INFO,
-               "INFO [debugged_module] [" __FILE__ ":%d]: Testing INFO",
+               _("INFO [debugged_module] [") __FILE__ _(":") "%d" _("]: Testing INFO"),
                __LINE__ + 1);
-    avs_log(debugged_module, INFO, "Testing INFO");
+    avs_log(debugged_module, INFO, _("Testing INFO"));
     ASSERT_LOG(debugged_module,
                WARNING,
-               "WARNING [debugged_module] [" __FILE__ ":%d]: Testing WARNING",
+               _("WARNING [debugged_module] [") __FILE__ _(":") "%d" _("]: Testing WARNING"),
                __LINE__ + 1);
-    avs_log(debugged_module, WARNING, "Testing WARNING");
+    avs_log(debugged_module, WARNING, _("Testing WARNING"));
     ASSERT_LOG(debugged_module,
                ERROR,
-               "ERROR [debugged_module] [" __FILE__ ":%d]: Testing ERROR",
+               _("ERROR [debugged_module] [") __FILE__ _(":") "%d" _("]: Testing ERROR"),
                __LINE__ + 1);
-    avs_log(debugged_module, ERROR, "Testing ERROR");
+    avs_log(debugged_module, ERROR, _("Testing ERROR"));
 
-    avs_log(stable_module, DEBUG, "Testing DEBUG");
-    avs_log(stable_module, INFO, "Testing INFO");
-    avs_log(stable_module, WARNING, "Testing WARNING");
+    avs_log(stable_module, DEBUG, _("Testing DEBUG"));
+    avs_log(stable_module, INFO, _("Testing INFO"));
+    avs_log(stable_module, WARNING, _("Testing WARNING"));
     ASSERT_LOG(stable_module,
                ERROR,
-               "ERROR [stable_module] [" __FILE__ ":%d]: Testing ERROR",
+               _("ERROR [stable_module] [") __FILE__ _(":") "%d" _("]: Testing ERROR"),
                __LINE__ + 1);
-    avs_log(stable_module, ERROR, "Testing ERROR");
+    avs_log(stable_module, ERROR, _("Testing ERROR"));
 
     /* default level is INFO */
-    avs_log(other_module, DEBUG, "Testing DEBUG");
+    avs_log(other_module, DEBUG, _("Testing DEBUG"));
     ASSERT_LOG(other_module,
                INFO,
-               "INFO [other_module] [" __FILE__ ":%d]: Testing INFO",
+               _("INFO [other_module] [") __FILE__ _(":") "%d" _("]: Testing INFO"),
                __LINE__ + 1);
-    avs_log(other_module, INFO, "Testing INFO");
+    avs_log(other_module, INFO, _("Testing INFO"));
     ASSERT_LOG(other_module,
                WARNING,
-               "WARNING [other_module] [" __FILE__ ":%d]: Testing WARNING",
+               _("WARNING [other_module] [") __FILE__ _(":") "%d" _("]: Testing WARNING"),
                __LINE__ + 1);
-    avs_log(other_module, WARNING, "Testing WARNING");
+    avs_log(other_module, WARNING, _("Testing WARNING"));
     ASSERT_LOG(other_module,
                ERROR,
-               "ERROR [other_module] [" __FILE__ ":%d]: Testing ERROR",
+               _("ERROR [other_module] [") __FILE__ _(":") "%d" _("]: Testing ERROR"),
                __LINE__ + 1);
-    avs_log(other_module, ERROR, "Testing ERROR");
+    avs_log(other_module, ERROR, _("Testing ERROR"));
 
     ASSERT_LOG_CLEAN;
     reset_everything();
@@ -234,50 +234,50 @@ AVS_UNIT_TEST(log, lazy_log) {
 
     ASSERT_LOG(debugged_module,
                DEBUG,
-               "DEBUG [debugged_module] [" __FILE__ ":%d]: Testing DEBUG 42",
+               _("DEBUG [debugged_module] [") __FILE__ _(":") "%d" _("]: Testing DEBUG 42"),
                __LINE__ + 1);
-    avs_log(debugged_module, LAZY_DEBUG, "Testing DEBUG %d", success());
+    avs_log(debugged_module, LAZY_DEBUG, _("Testing DEBUG ") "%d" , success());
     ASSERT_LOG(debugged_module,
                INFO,
-               "INFO [debugged_module] [" __FILE__ ":%d]: Testing INFO 42",
+               _("INFO [debugged_module] [") __FILE__ _(":") "%d" _("]: Testing INFO 42"),
                __LINE__ + 1);
-    avs_log(debugged_module, LAZY_INFO, "Testing INFO %d", success());
+    avs_log(debugged_module, LAZY_INFO, _("Testing INFO ") "%d" , success());
     ASSERT_LOG(debugged_module,
                WARNING,
-               "WARNING [debugged_module] [" __FILE__
-               ":%d]: Testing WARNING 42",
+               _("WARNING [debugged_module] [") __FILE__
+               _(":") "%d" _("]: Testing WARNING 42"),
                __LINE__ + 1);
-    avs_log(debugged_module, LAZY_WARNING, "Testing WARNING %d", success());
+    avs_log(debugged_module, LAZY_WARNING, _("Testing WARNING ") "%d" , success());
     ASSERT_LOG(debugged_module,
                ERROR,
-               "ERROR [debugged_module] [" __FILE__ ":%d]: Testing ERROR 42",
+               _("ERROR [debugged_module] [") __FILE__ _(":") "%d" _("]: Testing ERROR 42"),
                __LINE__ + 1);
-    avs_log(debugged_module, LAZY_ERROR, "Testing ERROR %d", success());
+    avs_log(debugged_module, LAZY_ERROR, _("Testing ERROR ") "%d" , success());
 
-    avs_log(stable_module, LAZY_DEBUG, "Testing DEBUG %d", fail());
-    avs_log(stable_module, LAZY_INFO, "Testing INFO %d", fail());
-    avs_log(stable_module, LAZY_WARNING, "Testing WARNING %d", fail());
+    avs_log(stable_module, LAZY_DEBUG, _("Testing DEBUG ") "%d" , fail());
+    avs_log(stable_module, LAZY_INFO, _("Testing INFO ") "%d" , fail());
+    avs_log(stable_module, LAZY_WARNING, _("Testing WARNING ") "%d" , fail());
     ASSERT_LOG(stable_module,
                ERROR,
-               "ERROR [stable_module] [" __FILE__ ":%d]: Testing ERROR 42",
+               _("ERROR [stable_module] [") __FILE__ _(":") "%d" _("]: Testing ERROR 42"),
                __LINE__ + 1);
-    avs_log(stable_module, LAZY_ERROR, "Testing ERROR %d", success());
+    avs_log(stable_module, LAZY_ERROR, _("Testing ERROR ") "%d" , success());
 
     /* default level is INFO */
     avs_log_lazy(other_module, DEBUG, "Testing DEBUG %d", fail());
     ASSERT_LOG(other_module,
                INFO,
-               "INFO [other_module] [" __FILE__ ":%d]: Testing INFO 42",
+               _("INFO [other_module] [") __FILE__ _(":") "%d" _("]: Testing INFO 42"),
                __LINE__ + 1);
     avs_log_lazy(other_module, INFO, "Testing INFO %d", success());
     ASSERT_LOG(other_module,
                WARNING,
-               "WARNING [other_module] [" __FILE__ ":%d]: Testing WARNING 42",
+               _("WARNING [other_module] [") __FILE__ _(":") "%d" _("]: Testing WARNING 42"),
                __LINE__ + 1);
     avs_log_lazy(other_module, WARNING, "Testing WARNING %d", success());
     ASSERT_LOG(other_module,
                ERROR,
-               "ERROR [other_module] [" __FILE__ ":%d]: Testing ERROR 42",
+               _("ERROR [other_module] [") __FILE__ _(":") "%d" _("]: Testing ERROR 42"),
                __LINE__ + 1);
     avs_log_lazy(other_module, ERROR, "Testing ERROR %d", success());
 
@@ -294,7 +294,7 @@ AVS_UNIT_TEST(log, truncated) {
     memset(&empty_va_list, 0, sizeof(empty_va_list));
 
     memset(buf, 'a', 32);
-    ASSERT_LOG(test, INFO, "INFO [test] [plik:1]: log to...");
+    ASSERT_LOG(test, INFO, _("INFO [test] [plik:1]: log to..."));
     log_with_buffer_unlocked_v(buf,
                                TEST_BUF_SIZE,
                                AVS_LOG_INFO,
@@ -305,7 +305,7 @@ AVS_UNIT_TEST(log, truncated) {
                                empty_va_list);
 
     memset(buf, 'a', 32);
-    ASSERT_LOG(test, INFO, "INFO [test] [pl");
+    ASSERT_LOG(test, INFO, _("INFO [test] [pl"));
     log_with_buffer_unlocked_v(buf,
                                16,
                                AVS_LOG_INFO,
@@ -316,7 +316,7 @@ AVS_UNIT_TEST(log, truncated) {
                                empty_va_list);
 
     memset(buf, 'a', 32);
-    ASSERT_LOG(test, INFO, "INFO [test] [plik:1]: 123456789");
+    ASSERT_LOG(test, INFO, _("INFO [test] [plik:1]: 123456789"));
     log_with_buffer_unlocked_v(buf,
                                TEST_BUF_SIZE,
                                AVS_LOG_INFO,

--- a/net/compat/posix/compat_addrinfo.c
+++ b/net/compat/posix/compat_addrinfo.c
@@ -160,7 +160,7 @@ avs_net_addrinfo_t *avs_net_addrinfo_resolve_ex(
         int flags,
         const avs_net_resolved_endpoint_t *preferred_endpoint) {
     if (avs_is_err(_avs_net_ensure_global_state())) {
-        LOG(ERROR, "avs_net global state initialization error");
+        LOG(ERROR, _("avs_net global state initialization error"));
         return NULL;
     }
 
@@ -168,7 +168,7 @@ avs_net_addrinfo_t *avs_net_addrinfo_resolve_ex(
     memset((void *) &hint, 0, sizeof(hint));
     hint.ai_family = _avs_net_get_af(family);
     if (family != AVS_NET_AF_UNSPEC && hint.ai_family == AF_UNSPEC) {
-        LOG(DEBUG, "Unsupported avs_net_af_t: %d", (int) family);
+        LOG(DEBUG, _("Unsupported avs_net_af_t: ") "%d" , (int) family);
         return NULL;
     }
     if (!(flags & AVS_NET_ADDRINFO_RESOLVE_F_NOADDRCONFIG)) {
@@ -182,14 +182,14 @@ avs_net_addrinfo_t *avs_net_addrinfo_resolve_ex(
     // so we use our own port parsing
     uint16_t port;
     if (port_from_string(&port, port_str)) {
-        LOG(ERROR, "Invalid port: %s", port_str);
+        LOG(ERROR, _("Invalid port: ") "%s" , port_str);
         return NULL;
     }
 
     avs_net_addrinfo_t *ctx =
             (avs_net_addrinfo_t *) avs_calloc(1, sizeof(avs_net_addrinfo_t));
     if (!ctx) {
-        LOG(ERROR, "Out of memory");
+        LOG(ERROR, _("Out of memory"));
         return NULL;
     }
 
@@ -218,10 +218,10 @@ avs_net_addrinfo_t *avs_net_addrinfo_resolve_ex(
     int error = getaddrinfo(host, NULL, &hint, &ctx->results);
     if (error) {
 #ifdef HAVE_GAI_STRERROR
-        LOG(DEBUG, "getaddrinfo() error: %s; family == (avs_net_af_t) %d",
+        LOG(DEBUG, _("getaddrinfo() error: ") "%s" _("; family == (avs_net_af_t) ") "%d" ,
             gai_strerror(error), (int) family);
 #else
-        LOG(DEBUG, "getaddrinfo() error: %d; family == (avs_net_af_t) %d",
+        LOG(DEBUG, _("getaddrinfo() error: ") "%d" _("; family == (avs_net_af_t) ") "%d" ,
             error, (int) family);
 #endif
         avs_net_addrinfo_delete(&ctx);

--- a/net/src/api.c
+++ b/net/src/api.c
@@ -357,11 +357,11 @@ get_constructor_for_socket_type(avs_net_socket_type_t type) {
                                           : _avs_net_create_dtls_socket;
 #else
         LOG(ERROR,
-            "could not create secure socket: (D)TLS support is disabled");
+            _("could not create secure socket: (D)TLS support is disabled"));
         return NULL;
 #endif // WITHOUT_SSL
     default:
-        LOG(ERROR, "unknown socket type: %d", (int) type);
+        LOG(ERROR, _("unknown socket type: ") "%d" , (int) type);
         return NULL;
     }
 }
@@ -371,7 +371,7 @@ static avs_error_t create_bare_socket(avs_net_socket_t **socket,
                                       const void *configuration) {
     avs_error_t err = _avs_net_ensure_global_state();
     if (avs_is_err(err)) {
-        LOG(ERROR, "avs_net global state initialization error");
+        LOG(ERROR, _("avs_net global state initialization error"));
         return err;
     }
 

--- a/net/src/mbedtls/data_loader.c
+++ b/net/src/mbedtls/data_loader.c
@@ -53,24 +53,24 @@ static avs_error_t append_cert_from_buffer(mbedtls_x509_crt *chain,
 static avs_error_t load_cert_from_file(mbedtls_x509_crt *chain,
                                        const char *name) {
 #ifdef MBEDTLS_FS_IO
-    LOG(DEBUG, "certificate <%s>: going to load", name);
+    LOG(DEBUG, _("certificate <") "%s" _(">: going to load"), name);
 
     int retval = -1;
     avs_error_t err = ((retval = mbedtls_x509_crt_parse_file(chain, name))
                                ? avs_errno(AVS_EPROTO)
                                : AVS_OK);
     if (avs_is_ok(err)) {
-        LOG(DEBUG, "certificate <%s>: loaded", name);
+        LOG(DEBUG, _("certificate <") "%s" _(">: loaded"), name);
     } else {
-        LOG(ERROR, "certificate <%s>: failed to load, result %d", name, retval);
+        LOG(ERROR, _("certificate <") "%s" _(">: failed to load, result ") "%d" , name, retval);
     }
     return err;
 #else  // MBEDTLS_FS_IO
     (void) chain;
     (void) name;
     LOG(DEBUG,
-        "certificate <%s>: mbed TLS configured without file system support, "
-        "cannot load",
+        _("certificate <") "%s" _(">: mbed TLS configured without file system support, ")
+        _("cannot load"),
         name);
     return avs_errno(AVS_ENOTSUP);
 #endif // MBEDTLS_FS_IO
@@ -79,7 +79,7 @@ static avs_error_t load_cert_from_file(mbedtls_x509_crt *chain,
 static avs_error_t load_ca_from_path(mbedtls_x509_crt *chain,
                                      const char *path) {
 #ifdef MBEDTLS_FS_IO
-    LOG(DEBUG, "certificates from path <%s>: going to load", path);
+    LOG(DEBUG, _("certificates from path <") "%s" _(">: going to load"), path);
 
     int retval = -1;
     // Note: this function returns negative value if nothing was loaded or
@@ -89,10 +89,10 @@ static avs_error_t load_ca_from_path(mbedtls_x509_crt *chain,
                                ? avs_errno(AVS_EPROTO)
                                : AVS_OK);
     if (avs_is_ok(err)) {
-        LOG(DEBUG, "certificates from path <%s>: some loaded; not loaded: %d",
+        LOG(DEBUG, _("certificates from path <") "%s" _(">: some loaded; not loaded: ") "%d" ,
             path, retval);
     } else {
-        LOG(ERROR, "certificates from path <%s>: failed to load, result %d",
+        LOG(ERROR, _("certificates from path <") "%s" _(">: failed to load, result ") "%d" ,
             path, retval);
     }
     return err;
@@ -100,8 +100,8 @@ static avs_error_t load_ca_from_path(mbedtls_x509_crt *chain,
     (void) chain;
     (void) path;
     LOG(DEBUG,
-        "certificates from path <%s>: mbed TLS configured without file system "
-        "support, cannot load",
+        _("certificates from path <") "%s" _(">: mbed TLS configured without file system ")
+        _("support, cannot load"),
         path);
     return avs_errno(AVS_ENOTSUP);
 #endif // MBEDTLS_FS_IO
@@ -116,19 +116,19 @@ _avs_net_mbedtls_load_ca_certs(mbedtls_x509_crt **out,
     switch (info->desc.source) {
     case AVS_NET_DATA_SOURCE_FILE:
         if (!info->desc.info.file.filename) {
-            LOG(ERROR, "attempt to load CA cert from file, but filename=NULL");
+            LOG(ERROR, _("attempt to load CA cert from file, but filename=NULL"));
             return avs_errno(AVS_EINVAL);
         }
         return load_cert_from_file(*out, info->desc.info.file.filename);
     case AVS_NET_DATA_SOURCE_PATH:
         if (!info->desc.info.path.path) {
-            LOG(ERROR, "attempt to load CA cert from path, but path=NULL");
+            LOG(ERROR, _("attempt to load CA cert from path, but path=NULL"));
             return avs_errno(AVS_EINVAL);
         }
         return load_ca_from_path(*out, info->desc.info.path.path);
     case AVS_NET_DATA_SOURCE_BUFFER:
         if (!info->desc.info.buffer.buffer) {
-            LOG(ERROR, "attempt to load CA cert from buffer, but buffer=NULL");
+            LOG(ERROR, _("attempt to load CA cert from buffer, but buffer=NULL"));
             return avs_errno(AVS_EINVAL);
         }
         return append_cert_from_buffer(*out, info->desc.info.buffer.buffer,
@@ -149,14 +149,14 @@ _avs_net_mbedtls_load_client_cert(mbedtls_x509_crt **out,
     case AVS_NET_DATA_SOURCE_FILE:
         if (!info->desc.info.file.filename) {
             LOG(ERROR,
-                "attempt to load client cert from file, but filename=NULL");
+                _("attempt to load client cert from file, but filename=NULL"));
             return avs_errno(AVS_EINVAL);
         }
         return load_cert_from_file(*out, info->desc.info.file.filename);
     case AVS_NET_DATA_SOURCE_BUFFER:
         if (!info->desc.info.buffer.buffer) {
             LOG(ERROR,
-                "attempt to load client cert from buffer, but buffer=NULL");
+                _("attempt to load client cert from buffer, but buffer=NULL"));
             return avs_errno(AVS_EINVAL);
         }
         return append_cert_from_buffer(*out, info->desc.info.buffer.buffer,
@@ -183,7 +183,7 @@ static avs_error_t load_private_key_from_file(mbedtls_pk_context *client_key,
                                               const char *filename,
                                               const char *password) {
 #ifdef MBEDTLS_FS_IO
-    LOG(DEBUG, "private key <%s>: going to load", filename);
+    LOG(DEBUG, _("private key <") "%s" _(">: going to load"), filename);
 
     int retval = -1;
     avs_error_t err =
@@ -191,9 +191,9 @@ static avs_error_t load_private_key_from_file(mbedtls_pk_context *client_key,
                      ? avs_errno(AVS_EPROTO)
                      : AVS_OK);
     if (avs_is_ok(err)) {
-        LOG(DEBUG, "private key <%s>: loaded", filename);
+        LOG(DEBUG, _("private key <") "%s" _(">: loaded"), filename);
     } else {
-        LOG(ERROR, "private key <%s>: failed, result %d", filename, retval);
+        LOG(ERROR, _("private key <") "%s" _(">: failed, result ") "%d" , filename, retval);
     }
     return err;
 #else  // MBEDTLS_FS_IO
@@ -201,8 +201,8 @@ static avs_error_t load_private_key_from_file(mbedtls_pk_context *client_key,
     (void) filename;
     (void) password;
     LOG(DEBUG,
-        "private key <%s>: mbed TLS configured without file system support, "
-        "cannot load",
+        _("private key <") "%s" _(">: mbed TLS configured without file system support, ")
+        _("cannot load"),
         filename);
     return avs_errno(AVS_ENOTSUP);
 #endif // MBEDTLS_FS_IO
@@ -218,7 +218,7 @@ _avs_net_mbedtls_load_client_key(mbedtls_pk_context **client_key,
     case AVS_NET_DATA_SOURCE_FILE:
         if (!info->desc.info.file.filename) {
             LOG(ERROR,
-                "attempt to load client key from file, but filename=NULL");
+                _("attempt to load client key from file, but filename=NULL"));
             return avs_errno(AVS_EINVAL);
         }
         return load_private_key_from_file(*client_key,
@@ -227,7 +227,7 @@ _avs_net_mbedtls_load_client_key(mbedtls_pk_context **client_key,
     case AVS_NET_DATA_SOURCE_BUFFER:
         if (!info->desc.info.buffer.buffer) {
             LOG(ERROR,
-                "attempt to load client key from buffer, but buffer=NULL");
+                _("attempt to load client key from buffer, but buffer=NULL"));
             return avs_errno(AVS_EINVAL);
         }
         return load_private_key_from_buffer(*client_key,

--- a/net/src/mbedtls/mbedtls_persistence.c
+++ b/net/src/mbedtls/mbedtls_persistence.c
@@ -116,8 +116,8 @@ static avs_error_t handle_cert_persistence(avs_persistence_context_t *ctx,
     if (data && avs_persistence_direction(ctx) == AVS_PERSISTENCE_RESTORE) {
         // avs_persistence_sized_buffer() could allocate memory if it is restore
         // case
-        LOG(WARNING, "x509 certificates support is not compiled in - ignoring "
-                     "restored certificate");
+        LOG(WARNING, _("x509 certificates support is not compiled in - ignoring ")
+                     _("restored certificate"));
         avs_free(data);
     }
     return AVS_OK;
@@ -223,12 +223,12 @@ avs_error_t _avs_net_mbedtls_session_save(mbedtls_ssl_session *session,
             avs_stream_write((avs_stream_t *) &out_buf_stream,
                              PERSISTENCE_MAGIC, sizeof(PERSISTENCE_MAGIC));
     if (avs_is_err(err)) {
-        LOG(ERROR, "Could not write session magic");
+        LOG(ERROR, _("Could not write session magic"));
     } else {
         ctx = avs_persistence_store_context_create(
                 (avs_stream_t *) &out_buf_stream);
         if (avs_is_err((err = handle_session_persistence(&ctx, session)))) {
-            LOG(ERROR, "Could not persist session data");
+            LOG(ERROR, _("Could not persist session data"));
         }
     }
     // ensure that everything after the persisted data is zeroes, to make
@@ -254,7 +254,7 @@ avs_error_t _avs_net_mbedtls_session_restore(mbedtls_ssl_session *out_session,
                                              const void *buf,
                                              size_t buf_size) {
     if (is_all_zeros(buf, buf_size)) {
-        LOG(TRACE, "Session data empty, not attempting restore");
+        LOG(TRACE, _("Session data empty, not attempting restore"));
         return avs_errno(AVS_EBADMSG);
     }
     avs_stream_inbuf_t in_buf_stream = AVS_STREAM_INBUF_STATIC_INITIALIZER;
@@ -264,10 +264,10 @@ avs_error_t _avs_net_mbedtls_session_restore(mbedtls_ssl_session *out_session,
     avs_error_t err = avs_persistence_magic(&ctx, PERSISTENCE_MAGIC,
                                             sizeof(PERSISTENCE_MAGIC));
     if (avs_is_err(err)) {
-        LOG(ERROR, "Could not restore session: invalid magic");
+        LOG(ERROR, _("Could not restore session: invalid magic"));
     } else if (avs_is_err(
                        (err = handle_session_persistence(&ctx, out_session)))) {
-        LOG(ERROR, "Could not restore session data");
+        LOG(ERROR, _("Could not restore session data"));
     }
     return err;
 }

--- a/net/src/openssl/data_loader.c
+++ b/net/src/openssl/data_loader.c
@@ -58,7 +58,7 @@ static inline void setup_password_callback(SSL_CTX *ctx, const char *password) {
 static avs_error_t
 load_ca_certs_from_paths(SSL_CTX *ctx, const char *file, const char *path) {
     AVS_ASSERT(!!file != !!path, "cannot use path and file at the same time");
-    LOG(DEBUG, "CA certificate <file=%s, path=%s>: going to load",
+    LOG(DEBUG, _("CA certificate <file=") "%s" _(", path=") "%s" _(">: going to load"),
         file ? file : "(null)", path ? path : "(null)");
 
     if (file) {
@@ -126,7 +126,7 @@ parse_cert(X509 **out_cert, const void *buffer, const size_t len) {
         break;
     }
     default:
-        LOG(ERROR, "unknown in-memory certificate format");
+        LOG(ERROR, _("unknown in-memory certificate format"));
         break;
     }
     return *out_cert ? AVS_OK : avs_errno(AVS_EPROTO);
@@ -154,27 +154,27 @@ _avs_net_openssl_load_ca_certs(SSL_CTX *ctx,
                                const avs_net_trusted_cert_info_t *info) {
     setup_password_callback(ctx, NULL);
     if (!SSL_CTX_set_default_verify_paths(ctx)) {
-        LOG(WARNING, "could not set default CA verify paths");
+        LOG(WARNING, _("could not set default CA verify paths"));
         log_openssl_error();
     }
 
     switch (info->desc.source) {
     case AVS_NET_DATA_SOURCE_FILE:
         if (!info->desc.info.file.filename) {
-            LOG(ERROR, "attempt to load CA cert from file, but filename=NULL");
+            LOG(ERROR, _("attempt to load CA cert from file, but filename=NULL"));
             return avs_errno(AVS_EINVAL);
         }
         return load_ca_certs_from_paths(ctx, info->desc.info.file.filename,
                                         NULL);
     case AVS_NET_DATA_SOURCE_PATH:
         if (!info->desc.info.path.path) {
-            LOG(ERROR, "attempt to load CA cert from path, but path=NULL");
+            LOG(ERROR, _("attempt to load CA cert from path, but path=NULL"));
             return avs_errno(AVS_EINVAL);
         }
         return load_ca_certs_from_paths(ctx, NULL, info->desc.info.path.path);
     case AVS_NET_DATA_SOURCE_BUFFER:
         if (!info->desc.info.buffer.buffer) {
-            LOG(ERROR, "attempt to load CA cert from buffer, but buffer=NULL");
+            LOG(ERROR, _("attempt to load CA cert from buffer, but buffer=NULL"));
             return avs_errno(AVS_EINVAL);
         }
         return load_ca_cert_from_buffer(ctx, info->desc.info.buffer.buffer,
@@ -187,7 +187,7 @@ _avs_net_openssl_load_ca_certs(SSL_CTX *ctx,
 
 static avs_error_t load_client_cert_from_file(SSL_CTX *ctx,
                                               const char *filename) {
-    LOG(DEBUG, "client certificate <%s>: going to load", filename);
+    LOG(DEBUG, _("client certificate <") "%s" _(">: going to load"), filename);
     // Try PEM.
     if (SSL_CTX_use_certificate_file(ctx, filename, SSL_FILETYPE_PEM) == 1) {
         return AVS_OK;
@@ -225,14 +225,14 @@ _avs_net_openssl_load_client_cert(SSL_CTX *ctx,
     case AVS_NET_DATA_SOURCE_FILE:
         if (!info->desc.info.file.filename) {
             LOG(ERROR,
-                "attempt to load client cert from file, but filename=NULL");
+                _("attempt to load client cert from file, but filename=NULL"));
             return avs_errno(AVS_EINVAL);
         }
         return load_client_cert_from_file(ctx, info->desc.info.file.filename);
     case AVS_NET_DATA_SOURCE_BUFFER:
         if (!info->desc.info.buffer.buffer) {
             LOG(ERROR,
-                "attempt to load client cert from buffer, but buffer=NULL");
+                _("attempt to load client cert from buffer, but buffer=NULL"));
             return avs_errno(AVS_EINVAL);
         }
         return load_client_cert_from_buffer(ctx, info->desc.info.buffer.buffer,
@@ -246,7 +246,7 @@ _avs_net_openssl_load_client_cert(SSL_CTX *ctx,
 static avs_error_t load_client_key_from_file(SSL_CTX *ctx,
                                              const char *filename,
                                              const char *password) {
-    LOG(DEBUG, "client key <%s>: going to load", filename);
+    LOG(DEBUG, _("client key <") "%s" _(">: going to load"), filename);
     setup_password_callback(ctx, password);
 
     // Try PEM.
@@ -283,7 +283,7 @@ static avs_error_t parse_key(EVP_PKEY **out_key,
         break;
     }
     default:
-        LOG(ERROR, "unknown in-memory certificate format");
+        LOG(ERROR, _("unknown in-memory certificate format"));
         break;
     }
     BIO_free(bio);
@@ -316,7 +316,7 @@ _avs_net_openssl_load_client_key(SSL_CTX *ctx,
     case AVS_NET_DATA_SOURCE_FILE:
         if (!info->desc.info.file.filename) {
             LOG(ERROR,
-                "attempt to load client key from file, but filename=NULL");
+                _("attempt to load client key from file, but filename=NULL"));
             return avs_errno(AVS_EINVAL);
         }
         return load_client_key_from_file(ctx, info->desc.info.file.filename,
@@ -324,7 +324,7 @@ _avs_net_openssl_load_client_key(SSL_CTX *ctx,
     case AVS_NET_DATA_SOURCE_BUFFER:
         if (!info->desc.info.buffer.buffer) {
             LOG(ERROR,
-                "attempt to load client key from buffer, but buffer=NULL");
+                _("attempt to load client key from buffer, but buffer=NULL"));
             return avs_errno(AVS_EINVAL);
         }
         return load_client_key_from_buffer(ctx, info->desc.info.buffer.buffer,

--- a/net/src/url.c
+++ b/net/src/url.c
@@ -123,7 +123,7 @@ int avs_url_percent_decode(char *data, size_t *unescaped_length) {
                 src += 3;
                 dst += 1;
             } else {
-                LOG(ERROR, "bad escape format (%%XX) ");
+                LOG(ERROR, _("bad escape format (%%XX) "));
                 return -1;
             }
         } else {
@@ -139,11 +139,11 @@ int avs_url_percent_decode(char *data, size_t *unescaped_length) {
 static int prepare_string(char *data) {
     size_t new_length = 0;
     if (avs_url_percent_decode(data, &new_length)) {
-        LOG(ERROR, "unescape failure");
+        LOG(ERROR, _("unescape failure"));
         return -1;
     }
     if (new_length != strlen(data)) {
-        LOG(ERROR, "string cannot include null byte");
+        LOG(ERROR, _("string cannot include null byte"));
         return -1;
     }
     return 0;
@@ -201,7 +201,7 @@ static int parse_username_and_password(const char *begin,
 
     if (!is_valid_credential(&parsed_url->data[user_ptr])
             || prepare_string(&parsed_url->data[user_ptr])) {
-        LOG(ERROR, "invalid username");
+        LOG(ERROR, _("invalid username"));
         return -1;
     }
     parsed_url->user_ptr = user_ptr;
@@ -222,7 +222,7 @@ static int parse_username_and_password(const char *begin,
 
     if (!is_valid_credential(&parsed_url->data[password_ptr])
             || prepare_string(&parsed_url->data[password_ptr])) {
-        LOG(ERROR, "invalid password");
+        LOG(ERROR, _("invalid password"));
         return -1;
     }
     parsed_url->password_ptr = password_ptr;
@@ -241,7 +241,7 @@ static int url_parse_credentials(const char **url,
     if (credentials_end && (!first_slash || credentials_end < first_slash)) {
         if (parse_username_and_password(*url, credentials_end, data_out_ptr,
                                         out_limit, parsed_url)) {
-            LOG(ERROR, "cannot parse credentials from URL");
+            LOG(ERROR, _("cannot parse credentials from URL"));
             return -1;
         }
         *url = credentials_end + 1;
@@ -261,7 +261,7 @@ static int url_parse_host(const char **url,
         }
         assert(**url == '\0' || **url == ']');
         if (*(*url)++ != ']') {
-            LOG(ERROR, "expected ] at the end of host address");
+            LOG(ERROR, _("expected ] at the end of host address"));
             return -1;
         }
     } else {
@@ -292,7 +292,7 @@ static int url_parse_port(const char **url,
     }
     assert(!isdigit((unsigned char) **url));
     if (**url != '\0' && **url != '/' && **url != '?') {
-        LOG(ERROR, "port should have numeric value");
+        LOG(ERROR, _("port should have numeric value"));
         return -1;
     }
     parsed_url->data[(*data_out_ptr)++] = '\0';
@@ -350,7 +350,7 @@ avs_url_t *avs_url_parse_lenient(const char *raw_url) {
     avs_url_t *out =
             (avs_url_t *) avs_malloc(offsetof(avs_url_t, data) + data_length);
     if (!out) {
-        LOG(ERROR, "out of memory");
+        LOG(ERROR, _("out of memory"));
         return NULL;
     }
     *out = (avs_url_t) {
@@ -398,13 +398,13 @@ static int is_valid_domain(const char *str) {
 
         if (c == '.') {
             if (prev_c == '.') {
-                LOG(ERROR, "consecutive dots in domain name");
+                LOG(ERROR, _("consecutive dots in domain name"));
                 return 0;
             }
 
             last_segment = str;
         } else if (!is_valid_url_domain_char(c)) {
-            LOG(ERROR, "invalid character in domain name: %c", c);
+            LOG(ERROR, _("invalid character in domain name: ") "%c" , c);
             return 0;
         }
 
@@ -413,7 +413,7 @@ static int is_valid_domain(const char *str) {
 
     /* Last segment MUST start with a letter */
     if (!isalpha((unsigned char) last_segment[0])) {
-        LOG(ERROR, "top-level domain does not start with a letter: %s",
+        LOG(ERROR, _("top-level domain does not start with a letter: ") "%s" ,
             last_segment);
         return 0;
     }
@@ -423,7 +423,7 @@ static int is_valid_domain(const char *str) {
 
 int avs_url_validate_host(const char *str) {
     if (!str) {
-        LOG(ERROR, "host part cannot be empty");
+        LOG(ERROR, _("host part cannot be empty"));
         return -1;
     }
     return (avs_net_validate_ip_address(AVS_NET_AF_INET4, str) == 0
@@ -458,7 +458,7 @@ int avs_url_validate_path(const char *str) {
 
 int avs_url_validate(const avs_url_t *url) {
     if (!url->has_protocol) {
-        LOG(ERROR, "no valid protocol in URL");
+        LOG(ERROR, _("no valid protocol in URL"));
         return -1;
     }
     if (avs_url_validate_host(avs_url_host(url))) {
@@ -467,7 +467,7 @@ int avs_url_validate(const avs_url_t *url) {
     if (url->port_ptr != URL_PTR_INVALID) {
         size_t port_length = strlen(&url->data[url->port_ptr]);
         if (port_length < 1 || port_length > 5) {
-            LOG(ERROR, "port number must be between 1 and 5 digits long");
+            LOG(ERROR, _("port number must be between 1 and 5 digits long"));
             return -1;
         }
     }
@@ -494,7 +494,7 @@ avs_url_t *avs_url_copy(const avs_url_t *url) {
     assert(alloc_size > 0 && (size_t) alloc_size > offsetof(avs_url_t, data));
     avs_url_t *out = (avs_url_t *) avs_malloc((size_t) alloc_size);
     if (!out) {
-        LOG(ERROR, "out of memory");
+        LOG(ERROR, _("out of memory"));
         return NULL;
     }
     memcpy(out, url, (size_t) alloc_size);

--- a/persistence/src/persistence.c
+++ b/persistence/src/persistence.c
@@ -125,7 +125,7 @@ static avs_error_t persist_sized_buffer(avs_persistence_context_t *ctx,
     uint32_t size32 = (uint32_t) *size_ptr;
     if (size32 != *size_ptr) {
         LOG(ERROR,
-            "Element too big to persist (%lu is larger than %" PRIu32 ")",
+            _("Element too big to persist (") "%lu" _(" is larger than ") "%" PRIu32 _(")"),
             (unsigned long) *size_ptr, UINT32_MAX);
     }
     avs_error_t err = persist_u32(ctx, &size32);
@@ -270,7 +270,7 @@ static avs_error_t restore_sized_buffer(avs_persistence_context_t *ctx,
         return AVS_OK;
     }
     if (!(*data_ptr = avs_malloc(size32))) {
-        LOG(ERROR, "Cannot allocate %" PRIu32 " bytes", size32);
+        LOG(ERROR, _("Cannot allocate ") "%" PRIu32 _(" bytes"), size32);
         return avs_errno(AVS_ENOMEM);
     }
     if (avs_is_err((err = restore_bytes(ctx, *data_ptr, size32)))) {
@@ -290,7 +290,7 @@ static avs_error_t restore_string(avs_persistence_context_t *ctx,
         return err;
     }
     if (size > 0 && (*string_ptr)[size - 1] != '\0') {
-        LOG(ERROR, "Invalid string");
+        LOG(ERROR, _("Invalid string"));
         avs_free(*string_ptr);
         *string_ptr = NULL;
         return avs_errno(AVS_EBADMSG);
@@ -589,12 +589,12 @@ avs_error_t avs_persistence_magic(avs_persistence_context_t *ctx,
     } else {
         void *bytes = avs_malloc(magic_size);
         if (!bytes) {
-            LOG(ERROR, "Out of memory");
+            LOG(ERROR, _("Out of memory"));
             return avs_errno(AVS_ENOMEM);
         }
         avs_error_t err = avs_persistence_bytes(ctx, bytes, magic_size);
         if (avs_is_ok(err) && memcmp(bytes, magic, magic_size) != 0) {
-            LOG(ERROR, "Magic markers do not match");
+            LOG(ERROR, _("Magic markers do not match"));
             err = avs_errno(AVS_EBADMSG);
         }
         avs_free(bytes);
@@ -617,7 +617,7 @@ avs_error_t avs_persistence_version(avs_persistence_context_t *ctx,
         }
     }
 
-    LOG(ERROR, "Unsupported version number: %u", (unsigned) *version_number);
+    LOG(ERROR, _("Unsupported version number: ") "%u" , (unsigned) *version_number);
     return avs_errno(AVS_EBADMSG);
 }
 

--- a/stream/net/src/netbuf.c
+++ b/stream/net/src/netbuf.c
@@ -109,7 +109,7 @@ static avs_error_t in_buffer_read_some(buffered_netstream_t *stream,
     size_t space_left = avs_buffer_space_left(in_buffer);
 
     if (!space_left) {
-        LOG(ERROR, "cannot read more data - buffer is full");
+        LOG(ERROR, _("cannot read more data - buffer is full"));
         return avs_errno(AVS_ENOBUFS);
     }
 
@@ -202,7 +202,7 @@ static avs_error_t try_recv_nonblock(buffered_netstream_t *stream) {
                                    stream->socket,
                                    AVS_NET_SOCKET_OPT_RECV_TIMEOUT,
                                    zero_timeout)))) {
-        LOG(ERROR, "cannot set socket timeout");
+        LOG(ERROR, _("cannot set socket timeout"));
         return err;
     }
 
@@ -216,7 +216,7 @@ static avs_error_t try_recv_nonblock(buffered_netstream_t *stream) {
     avs_error_t restore_err = avs_net_socket_set_opt(
             stream->socket, AVS_NET_SOCKET_OPT_RECV_TIMEOUT, old_recv_timeout);
     if (avs_is_ok(restore_err)) {
-        LOG(ERROR, "cannot restore socket timeout");
+        LOG(ERROR, _("cannot restore socket timeout"));
         if (avs_is_ok(err)) {
             err = restore_err;
         }
@@ -252,17 +252,17 @@ buffered_netstream_peek(avs_stream_t *stream_, size_t offset, char *out_value) {
             size_t bytes_read;
             avs_error_t err = in_buffer_read_some(stream, &bytes_read);
             if (avs_is_err(err)) {
-                LOG(ERROR, "cannot peek - read error");
+                LOG(ERROR, _("cannot peek - read error"));
                 return err;
             } else if (bytes_read == 0) {
-                LOG(ERROR, "cannot peek - 0 bytes read");
+                LOG(ERROR, _("cannot peek - 0 bytes read"));
                 return AVS_EOF;
             }
         }
         *out_value = avs_buffer_data(stream->in_buffer)[offset];
         return AVS_OK;
     } else {
-        LOG(ERROR, "cannot peek - buffer is too small");
+        LOG(ERROR, _("cannot peek - buffer is too small"));
         return avs_errno(AVS_EINVAL);
     }
 }
@@ -328,7 +328,7 @@ int avs_stream_netbuf_create(avs_stream_t **stream_,
     *stream_ = (avs_stream_t *) stream;
 
     if (!*stream_) {
-        LOG(ERROR, "cannot allocate memory");
+        LOG(ERROR, _("cannot allocate memory"));
         return -1;
     }
 
@@ -337,11 +337,11 @@ int avs_stream_netbuf_create(avs_stream_t **stream_,
 
     stream->socket = socket;
     if (avs_buffer_create(&stream->in_buffer, in_buffer_size)) {
-        LOG(ERROR, "cannot create input buffer");
+        LOG(ERROR, _("cannot create input buffer"));
         goto buffered_netstream_create_error;
     }
     if (avs_buffer_create(&stream->out_buffer, out_buffer_size)) {
-        LOG(ERROR, "cannot create output buffer");
+        LOG(ERROR, _("cannot create output buffer"));
         goto buffered_netstream_create_error;
     }
     return 0;
@@ -361,7 +361,7 @@ int avs_stream_netbuf_transfer(avs_stream_t *destination_,
 
     if (source->vtable != &buffered_netstream_vtable
             || destination->vtable != &buffered_netstream_vtable) {
-        LOG(ERROR, "buffers can be transferred only between netbuf streams");
+        LOG(ERROR, _("buffers can be transferred only between netbuf streams"));
         return -1;
     }
 
@@ -369,7 +369,7 @@ int avs_stream_netbuf_transfer(avs_stream_t *destination_,
                     < avs_buffer_data_size(source->out_buffer)
             || avs_buffer_space_left(destination->in_buffer)
                            < avs_buffer_data_size(source->in_buffer)) {
-        LOG(ERROR, "no space left in destination buffer");
+        LOG(ERROR, _("no space left in destination buffer"));
         return -1;
     }
 
@@ -390,7 +390,7 @@ int avs_stream_netbuf_transfer(avs_stream_t *destination_,
 int avs_stream_netbuf_out_buffer_left(avs_stream_t *str) {
     buffered_netstream_t *stream = (buffered_netstream_t *) str;
     if (stream->vtable != &buffered_netstream_vtable) {
-        LOG(ERROR, "not a buffered_netstream");
+        LOG(ERROR, _("not a buffered_netstream"));
         return -1;
     }
     return (int) avs_buffer_space_left(stream->out_buffer);

--- a/stream/src/stream_buffered.c
+++ b/stream/src/stream_buffered.c
@@ -207,10 +207,10 @@ stream_buffered_peek(avs_stream_t *stream_, size_t offset, char *out_value) {
             size_t bytes_read;
             avs_error_t err = fetch_data(stream, &bytes_read);
             if (avs_is_err(err)) {
-                LOG(ERROR, "cannot peek - read error");
+                LOG(ERROR, _("cannot peek - read error"));
                 return err;
             } else if (bytes_read == 0) {
-                LOG(ERROR, "cannot peek - 0 bytes read");
+                LOG(ERROR, _("cannot peek - 0 bytes read"));
                 return stream->message_finished ? AVS_EOF
                                                 : avs_errno(AVS_ENOBUFS);
             }
@@ -224,8 +224,8 @@ stream_buffered_peek(avs_stream_t *stream_, size_t offset, char *out_value) {
                             offset - avs_buffer_data_size(stream->in_buffer),
                             out_value);
     if (avs_is_err(err)) {
-        LOG(ERROR, "cannot peek - buffer is too small and underlying stream's "
-                   "peek failed");
+        LOG(ERROR, _("cannot peek - buffer is too small and underlying stream's ")
+                   _("peek failed"));
         if (err.category == AVS_ERRNO_CATEGORY && err.code == AVS_ENOTSUP) {
             // underlying stream does not support peeking - map it to ENOBUFS
             return avs_errno(AVS_ENOBUFS);
@@ -274,15 +274,15 @@ int avs_stream_buffered_create(avs_stream_t **inout_stream,
                                size_t in_buffer_size,
                                size_t out_buffer_size) {
     if (!inout_stream || !*inout_stream) {
-        LOG(ERROR, "No underlying stream provided!");
+        LOG(ERROR, _("No underlying stream provided!"));
         return -1;
     }
     if (!in_buffer_size && !out_buffer_size) {
-        LOG(ERROR, "At least one buffer has to be non-zero sized");
+        LOG(ERROR, _("At least one buffer has to be non-zero sized"));
         return -1;
     }
     if (in_buffer_size > SIZE_MAX / 2 || out_buffer_size > SIZE_MAX / 2) {
-        LOG(ERROR, "Buffer size is too big");
+        LOG(ERROR, _("Buffer size is too big"));
         return -1;
     }
 

--- a/stream/src/stream_outbuf.c
+++ b/stream/src/stream_outbuf.c
@@ -72,7 +72,7 @@ size_t avs_stream_outbuf_offset(avs_stream_outbuf_t *stream) {
 avs_error_t avs_stream_outbuf_set_offset(avs_stream_outbuf_t *stream,
                                          size_t offset) {
     if (offset > stream->buffer_offset) {
-        LOG(ERROR, "outbuf stream offset cannot be advanced");
+        LOG(ERROR, _("outbuf stream offset cannot be advanced"));
         return avs_errno(AVS_ERANGE);
     }
     stream->buffer_offset = offset;

--- a/unit/src/mocksock.c
+++ b/unit/src/mocksock.c
@@ -297,7 +297,7 @@ static void finish_command(mocksock_t *socket) {
 
 static avs_error_t
 mock_connect(avs_net_socket_t *socket_, const char *host, const char *port) {
-    LOG(TRACE, "mock_connect: host <%s>, port <%s>", host, port);
+    LOG(TRACE, _("mock_connect: host <") "%s" _(">, port <") "%s" _(">"), host, port);
 
     avs_error_t err = AVS_OK;
     mocksock_t *socket = (mocksock_t *) socket_;
@@ -388,7 +388,7 @@ static void hexdump_data(const void *raw_data, size_t data_size) {
     for (size_t offset = 0; offset < data_size; offset += bytes_per_row) {
         hexdumpify(buffer, buffer_size, data + offset, data_size - offset,
                    bytes_per_segment, segments_per_row);
-        LOG(TRACE, "%s", buffer);
+        LOG(TRACE,  "%s" , buffer);
     }
 
     avs_free(buffer);
@@ -408,7 +408,7 @@ static avs_error_t mock_send_to(avs_net_socket_t *socket_,
                                 size_t buffer_length,
                                 const char *host,
                                 const char *port) {
-    LOG(TRACE, "mock_send_to: host <%s>, port <%s>, %zu bytes", host, port,
+    LOG(TRACE, _("mock_send_to: host <") "%s" _(">, port <") "%s" _(">, ") "%zu" _(" bytes"), host, port,
         buffer_length);
     hexdump_data(buffer, buffer_length);
 
@@ -437,12 +437,12 @@ static avs_error_t mock_send_to(avs_net_socket_t *socket_,
             socket->expected_data->args.valid.ptr += to_send;
             if (socket->expected_data->args.valid.ptr
                     == socket->expected_data->args.valid.size) {
-                LOG(TRACE, "mock_send_to: item fully sent");
+                LOG(TRACE, _("mock_send_to: item fully sent"));
                 avs_free((void *) (intptr_t)
                                  socket->expected_data->args.valid.data);
                 finish_data(socket);
             } else {
-                LOG(TRACE, "mock_send_to: partial send, %u/%u",
+                LOG(TRACE, _("mock_send_to: partial send, ") "%u" _("/") "%u" ,
                     (unsigned) to_send,
                     (unsigned) socket->expected_data->args.valid.size);
             }
@@ -453,14 +453,14 @@ static avs_error_t mock_send_to(avs_net_socket_t *socket_,
             avs_error_t err = socket->expected_data->args.retval;
             finish_data(socket);
 
-            LOG(TRACE, "mock_send_to: failure");
+            LOG(TRACE, _("mock_send_to: failure"));
             return err;
         } else {
             AVS_UNIT_ASSERT_TRUE(!"mock_send_to: unexpected send");
         }
     }
 
-    LOG(TRACE, "mock_send_to: sent %zu B", buffer_length);
+    LOG(TRACE, _("mock_send_to: sent ") "%zu" _(" B"), buffer_length);
     return AVS_OK;
 }
 
@@ -487,7 +487,7 @@ static avs_error_t mock_receive_from(avs_net_socket_t *socket_,
                                      size_t out_host_size,
                                      char *out_port,
                                      size_t out_port_size) {
-    LOG(TRACE, "mock_receive_from: buffer_length %zu", buffer_length);
+    LOG(TRACE, _("mock_receive_from: buffer_length ") "%zu" , buffer_length);
 
     mocksock_t *socket = (mocksock_t *) socket_;
     avs_error_t err = AVS_OK;
@@ -515,13 +515,13 @@ static avs_error_t mock_receive_from(avs_net_socket_t *socket_,
                          socket->expected_data->args.valid.remote_port);
         if (socket->expected_data->args.valid.ptr
                 == socket->expected_data->args.valid.size) {
-            LOG(TRACE, "mock_receive_from: item fully received");
+            LOG(TRACE, _("mock_receive_from: item fully received"));
             socket->last_data_read = socket->expected_data->args.valid.ptr;
             avs_free(
                     (void *) (intptr_t) socket->expected_data->args.valid.data);
             finish_data(socket);
         } else {
-            LOG(TRACE, "mock_receive_from: partial receive, %u/%u",
+            LOG(TRACE, _("mock_receive_from: partial receive, ") "%u" _("/") "%u" ,
                 (unsigned) *out,
                 (unsigned) socket->expected_data->args.valid.size);
 
@@ -536,11 +536,11 @@ static avs_error_t mock_receive_from(avs_net_socket_t *socket_,
         err = socket->expected_data->args.retval;
         finish_data(socket);
 
-        LOG(TRACE, "mock_receive_from: failure");
+        LOG(TRACE, _("mock_receive_from: failure"));
         return err;
     }
 
-    LOG(TRACE, "mock_receive_from: recv %zu/%zu B, host <%s>, port <%s>", *out,
+    LOG(TRACE, _("mock_receive_from: recv ") "%zu" _("/") "%zu" _(" B, host <") "%s" _(">, port <") "%s" _(">"), *out,
         buffer_length, out_host, out_port);
     hexdump_data(buffer, *out);
     return err;
@@ -556,7 +556,7 @@ static avs_error_t mock_receive(avs_net_socket_t *socket,
 
 static avs_error_t
 mock_bind(avs_net_socket_t *socket_, const char *localaddr, const char *port) {
-    LOG(TRACE, "mock_bind: localaddr <%s>, port <%s>", localaddr, port);
+    LOG(TRACE, _("mock_bind: localaddr <") "%s" _(">, port <") "%s" _(">"), localaddr, port);
 
     avs_error_t err = AVS_OK;
     mocksock_t *socket = (mocksock_t *) socket_;
@@ -885,7 +885,7 @@ void avs_unit_mocksock_expect_output_to__(
         const char *host,
         const char *port,
         const mocksock_additional_args_t *args) {
-    LOG(TRACE, "expect_output: %zuB", length);
+    LOG(TRACE, _("expect_output: ") "%zuB" , length);
     hexdump_data(expect, length);
 
     mocksock_t *socket = (mocksock_t *) socket_;

--- a/utils/src/shared_buffer.c
+++ b/utils/src/shared_buffer.c
@@ -33,8 +33,8 @@ uint8_t *_avs_shared_buffer_acquire(avs_shared_buffer_t *buf,
                                     unsigned line) {
     if (buf->avs_shared_buffer_private_data.file) {
         LOG(ERROR,
-            "double use of a shared buffer in %s (%s:%u); last acquired "
-            "in %s (%s:%u) and not released yet",
+            _("double use of a shared buffer in ") "%s" _(" (") "%s" _(":") "%u" _("); last acquired ")
+            _("in ") "%s" _(" (") "%s" _(":") "%u" _(") and not released yet"),
             func, file, line, buf->avs_shared_buffer_private_data.func,
             buf->avs_shared_buffer_private_data.file,
             buf->avs_shared_buffer_private_data.line);


### PR DESCRIPTION
This introduces `AVS_DISPOSABLE_LOG(Arg)` macro (aliased for internal purposes
to `_()`) which causes the portion of the log passed as `Arg` to transmute into single
whitespace when `WITH_AVS_MICRO_LOGS` CMake option is enabled.

This reduces binary size in cases where the application logs a lot and
has some static strings that can be omitted in release builds without
the huge loss of information.