### PR TITLE
Avoid IMPORTED keyword in our workaround for global target aliasing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ macro(avs_install_export TNAME CNAME)
         # cannot be aliased. So let's create an INTERFACE target instead...
         set_property(GLOBAL APPEND_STRING PROPERTY AVS_ALIASED_TARGETS "
                      if(NOT TARGET ${TNAME} AND TARGET ${_ALIASED_TARGET})
-                         add_library(${TNAME} INTERFACE IMPORTED)
+                         add_library(${TNAME} INTERFACE)
                          target_link_libraries(${TNAME} INTERFACE ${_ALIASED_TARGET})
                      endif()")
     else()


### PR DESCRIPTION
Avoid IMPORTED keyword in our workaround for not being able to alias global targets.
With IMPORTED keyword on CMake 3.5.x this leads to:

"Cannot specify link libraries for tagrget which is not built by this project"
whenever one attempts to link against avs_commons.