### PR TITLE
Change muliple arguments to PKCS11 uri

### DIFF
--- a/include_public/avsystem/commons/avs_crypto_pki.h
+++ b/include_public/avsystem/commons/avs_crypto_pki.h
@@ -834,62 +834,38 @@ avs_error_t avs_crypto_pki_ec_gen(avs_crypto_prng_ctx_t *prng_ctx,
  * from it) suitable for use with elliptic curve cryptography, using PKCS11
  * engine.
  *
- * @param token Token on which the keys will be generated.
- *
- * @param label Label for the generated keys.
- *
- * @param pin   Password to the token.
+ * @param query PCKS11 URI of the keys.
  */
-avs_error_t avs_crypto_pki_ec_gen_pkcs11(const char *token,
-                                         const char *label,
-                                         const char *pin);
+avs_error_t avs_crypto_pki_engine_key_gen(const char *query);
 
 /**
  * Removes a private key and the corresponding public key from HSM using PKCS11.
  *
- * @param token Token from which the key will be removed.
- *
- * @param label Label of the key to remove.
- *
- * @param pin   Password to the token.
+ * @param query PCKS11 URI of the keys.
  */
-avs_error_t avs_crypto_pki_ec_rm_pkcs11(const char *token,
-                                        const char *label,
-                                        const char *pin);
+avs_error_t avs_crypto_pki_engine_key_rm(const char *query);
 
 /**
  * Stores an X.509 certificate given as @ref avs_crypto_certificate_chain_info_t
  * in a HSM using PKCS11.
  *
- * @param token     Token on which the certificate will be stored.
- *
- * @param label     Label for the stored certificate.
- *
- * @param pin       Password to the token.
+ * @param query PCKS11 URI of the cert.
  *
  * @param cert_info Reference to a certificate to store. Note that if the
  *                  given input contains more than one certificate, only the
  *                  first one is stored.
  */
-avs_error_t avs_crypto_pki_certificate_store_pkcs11(
-        const char *token,
-        const char *label,
-        const char *pin,
+avs_error_t avs_crypto_pki_engine_certificate_store(
+        const char *query,
         const avs_crypto_certificate_chain_info_t *cert_info);
 
 /**
  * Removes an X.509 certificate from HSM using PKCS11.
  *
- * @param token Token from which the certificate will be removed.
- *
- * @param label Label of the certificate to remove.
- *
- * @param pin   Password to the token.
+ * @param query PCKS11 URI of the cert.
  */
-avs_error_t avs_crypto_pki_certificate_rm_pkcs11(const char *token,
-                                                 const char *label,
-                                                 const char *pin);
-#    endif // AVS_COMMONS_WITH_AVS_CRYPTO_ENGINE
+avs_error_t avs_crypto_pki_engine_certificate_rm(const char *query);
+#    endif // AVS_COMMONS_WITH_OPENSSL_PKCS11_ENGINE
 
 /**
  * Structure representing a type of a Distinguished Name attribute.

--- a/src/net/avs_url.c
+++ b/src/net/avs_url.c
@@ -104,40 +104,6 @@ avs_error_t avs_url_percent_encode(avs_stream_t *stream,
     return AVS_OK;
 }
 
-int avs_url_percent_decode(char *data, size_t *unescaped_length) {
-    char *src = data, *dst = data;
-
-    if (!strchr(data, '%')) {
-        /* nothing to unescape */
-        *unescaped_length = strlen(data);
-        return 0;
-    }
-
-    while (*src) {
-        if (*src == '%') {
-            if (isxdigit((unsigned char) src[1])
-                    && isxdigit((unsigned char) src[2])) {
-                char ascii[3];
-                ascii[0] = src[1];
-                ascii[1] = src[2];
-                ascii[2] = '\0';
-                *dst = (char) strtoul(ascii, NULL, 16);
-                src += 3;
-                dst += 1;
-            } else {
-                LOG(ERROR, _("bad escape format (%%XX) "));
-                return -1;
-            }
-        } else {
-            *dst++ = *src++;
-        }
-    }
-    *dst = '\0';
-
-    *unescaped_length = (size_t) (dst - data);
-    return 0;
-}
-
 static int prepare_string(char *data) {
     size_t new_length = 0;
     if (avs_url_percent_decode(data, &new_length)) {

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(avs_utils STATIC
             avs_strerror.c
             avs_time.c
             avs_token.c
+            avs_url_common.c
 
             compat/posix/avs_compat_time.c
             compat/stdlib/avs_memory.c)

--- a/src/utils/avs_url_common.c
+++ b/src/utils/avs_url_common.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 AVSystem <avsystem@avsystem.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Functions excluded from avs_url.c in "net" because they are used also
+ * in the other modules.
+ *
+ * In the future the whole avs_url.c should be moved to the separate module
+ */
+
+#include <avs_commons_init.h>
+
+#ifdef AVS_COMMONS_WITH_AVS_UTILS
+
+#    include <assert.h>
+#    include <ctype.h>
+#    include <stdlib.h>
+#    include <string.h>
+
+#    include <avsystem/commons/avs_memory.h>
+#    include <avsystem/commons/avs_url.h>
+#    include <avsystem/commons/avs_utils.h>
+
+#    define MODULE_NAME avs_utils
+#    include <avs_x_log_config.h>
+
+VISIBILITY_SOURCE_BEGIN
+
+#    define URL_PTR_INVALID SIZE_MAX
+
+int avs_url_percent_decode(char *data, size_t *unescaped_length) {
+    char *src = data, *dst = data;
+
+    if (!strchr(data, '%')) {
+        /* nothing to unescape */
+        *unescaped_length = strlen(data);
+        return 0;
+    }
+
+    while (*src) {
+        if (*src == '%') {
+            if (isxdigit((unsigned char) src[1])
+                    && isxdigit((unsigned char) src[2])) {
+                char ascii[3];
+                ascii[0] = src[1];
+                ascii[1] = src[2];
+                ascii[2] = '\0';
+                *dst = (char) strtoul(ascii, NULL, 16);
+                src += 3;
+                dst += 1;
+            } else {
+                LOG(ERROR, _("bad escape format (%%XX) "));
+                return -1;
+            }
+        } else {
+            *dst++ = *src++;
+        }
+    }
+    *dst = '\0';
+
+    *unescaped_length = (size_t) (dst - data);
+    return 0;
+}
+
+#endif // AVS_COMMONS_WITH_AVS_UTILS


### PR DESCRIPTION
Currently we use a three arguments in functions for key generation
and removal: pin, token and label. To make it more adjustable,
this review changes it to one string containing some API dependent
address for the keys - in the case of PKCS11 we use PKCS11 uri.