### PR TITLE
Fix key loading from buffer for mbedtls

### DIFF
--- a/src/crypto/avs_crypto_utils.c
+++ b/src/crypto/avs_crypto_utils.c
@@ -644,6 +644,18 @@ bool _avs_crypto_aead_parameters_valid(size_t key_len,
     return true;
 }
 
+_avs_crypto_cert_encoding_t _avs_crypto_detect_cert_encoding(const void *buffer,
+                                                             size_t len) {
+    static const char PEM_PREFIX[] = "-----BEGIN ";
+    assert(buffer || !len);
+    if (len >= strlen(PEM_PREFIX)
+            && !memcmp(buffer, PEM_PREFIX, strlen(PEM_PREFIX))) {
+        return ENCODING_PEM;
+    } else {
+        return ENCODING_DER;
+    }
+}
+
 #    endif // AVS_COMMONS_WITH_AVS_CRYPTO_ADVANCED_FEATURES
 
 #endif // AVS_COMMONS_WITH_AVS_CRYPTO

--- a/src/crypto/avs_crypto_utils.h
+++ b/src/crypto/avs_crypto_utils.h
@@ -56,6 +56,10 @@ bool _avs_crypto_aead_parameters_valid(size_t key_len,
                                        size_t iv_len,
                                        size_t tag_len);
 
+typedef enum { ENCODING_PEM, ENCODING_DER } _avs_crypto_cert_encoding_t;
+
+_avs_crypto_cert_encoding_t _avs_crypto_detect_cert_encoding(const void *buffer, size_t len);
+
 VISIBILITY_PRIVATE_HEADER_END
 
 #endif // AVS_COMMONS_CRYPTO_UTILS_H

--- a/src/crypto/mbedtls/avs_mbedtls_data_loader.h
+++ b/src/crypto/mbedtls/avs_mbedtls_data_loader.h
@@ -39,7 +39,7 @@ avs_error_t _avs_crypto_mbedtls_load_crls(
 void _avs_crypto_mbedtls_pk_context_cleanup(mbedtls_pk_context **ctx);
 
 avs_error_t
-_avs_crypto_mbedtls_load_client_key(mbedtls_pk_context **pk,
+_avs_crypto_mbedtls_load_private_key(mbedtls_pk_context **pk,
                                     const avs_crypto_private_key_info_t *info);
 
 VISIBILITY_PRIVATE_HEADER_END

--- a/src/crypto/mbedtls/avs_mbedtls_pki.c
+++ b/src/crypto/mbedtls/avs_mbedtls_pki.c
@@ -226,7 +226,7 @@ avs_crypto_pki_csr_create(avs_crypto_prng_ctx_t *prng_ctx,
 
     err = convert_subject(&csr_ctx.subject, subject);
     if (avs_is_ok(err)
-            && avs_is_ok((err = _avs_crypto_mbedtls_load_client_key(
+            && avs_is_ok((err = _avs_crypto_mbedtls_load_private_key(
                                   &private_key, private_key_info)))) {
         assert(private_key);
         mbedtls_x509write_csr_set_key(&csr_ctx, private_key);

--- a/src/crypto/openssl/avs_openssl_data_loader.c
+++ b/src/crypto/openssl/avs_openssl_data_loader.c
@@ -51,19 +51,6 @@
 
 VISIBILITY_SOURCE_BEGIN
 
-typedef enum { ENCODING_PEM, ENCODING_DER } encoding_t;
-
-static encoding_t detect_encoding(const void *buffer, size_t len) {
-    static const char PEM_PREFIX[] = "-----BEGIN ";
-    assert(buffer || !len);
-    if (len >= strlen(PEM_PREFIX)
-            && !memcmp(buffer, PEM_PREFIX, strlen(PEM_PREFIX))) {
-        return ENCODING_PEM;
-    } else {
-        return ENCODING_DER;
-    }
-}
-
 static int password_cb(char *buf, int num, int rwflag, void *userdata) {
     (void) rwflag;
     if (!userdata) {
@@ -207,7 +194,7 @@ load_pem_or_der_objects(const void *buffer,
                         avs_crypto_ossl_object_load_t *load_cb,
                         void *load_cb_arg) {
     assert(buffer || !len);
-    switch (detect_encoding(buffer, len)) {
+    switch (_avs_crypto_detect_cert_encoding(buffer, len)) {
     case ENCODING_PEM:
         return load_pem_objects(buffer, len, password, type, load_cb,
                                 load_cb_arg);

--- a/src/net/mbedtls/avs_mbedtls_socket.c
+++ b/src/net/mbedtls/avs_mbedtls_socket.c
@@ -1373,7 +1373,7 @@ configure_ssl_certs(ssl_socket_certs_t *certs,
                 LOG(ERROR, _("could not rebuild client certificate chain"));
             }
             if (avs_is_ok(err)
-                    && avs_is_err((err = _avs_crypto_mbedtls_load_client_key(
+                    && avs_is_err((err = _avs_crypto_mbedtls_load_private_key(
                                            &certs->client_key,
                                            &cert_info->client_key)))) {
                 LOG(ERROR, _("could not load client private key"));

--- a/tests/crypto/openssl_engine/openssl_engine_data_loader.c
+++ b/tests/crypto/openssl_engine/openssl_engine_data_loader.c
@@ -277,7 +277,7 @@ AVS_UNIT_TEST(backend_openssl_engine, cert_loading_from_pkcs11) {
     AVS_UNIT_ASSERT_SUCCESS(system(pkcs11_command));
 
     // Loading certificate
-    const char *cert_uri = make_pkcs11_uri(TOKEN, cert_label, PIN);
+    char *cert_uri = make_pkcs11_uri(TOKEN, cert_label, PIN);
     const avs_crypto_certificate_chain_info_t cert_info =
             avs_crypto_certificate_chain_info_from_engine(cert_uri);
     X509 *cert = NULL;


### PR DESCRIPTION
Summary:
Adds NULL termination to the buffer when needed, before feeding it
to the mbedtls_pk_parse_key function

Adds tests for loading keys from buffers

Renames mbedtls key loading functions to make them more consistent