### PR TITLE
Wrapped avs_stream_common.c with AVS_COMMONS_WITH_AVS_STREAM

### DIFF
--- a/src/stream/avs_stream_common.c
+++ b/src/stream/avs_stream_common.c
@@ -16,9 +16,13 @@
 
 #include "avs_stream_common.h"
 
+#ifdef AVS_COMMONS_WITH_AVS_STREAM
+
 VISIBILITY_SOURCE_BEGIN
 
 avs_error_t _avs_stream_empty_finish_message(avs_stream_t *stream) {
     (void) stream;
     return AVS_OK;
 }
+
+#endif // AVS_COMMONS_WITH_AVS_STREAM


### PR DESCRIPTION
When `AVS_COMMONS_WITH_AVS_STREAM` is not defined, `avs_stream_common.c` yields compilation errors because of lacking typedefs for `avs_error_t` and `avs_stream_t`.

This rule should fix it.