### PR TITLE
Optimizing the avs_url_percent_decode() function

### DIFF
--- a/src/url/avs_url.c
+++ b/src/url/avs_url.c
@@ -108,12 +108,14 @@ avs_error_t avs_url_percent_encode(avs_stream_t *stream,
 int avs_url_percent_decode(char *data, size_t *unescaped_length) {
     char *src = data, *dst = data;
 
-    if (!strchr(data, '%')) {
+    src = strchr(data, '%');
+    if (!src) {
         /* nothing to unescape */
         *unescaped_length = strlen(data);
         return 0;
     }
 
+    dst = src;
     while (*src) {
         if (*src == '%') {
             if (isxdigit((unsigned char) src[1])


### PR DESCRIPTION
In the proposed version the while loop starts from '%' char (if present) and not from the begining as in the original.

Issue #305 
