### PR TITLE
Fix segfault in avs_consume_quotable_token()

### DIFF
--- a/src/utils/avs_token.c
+++ b/src/utils/avs_token.c
@@ -53,6 +53,8 @@ void avs_consume_quotable_token(const char **src,
 
     if (dest_size == 0) {
         dest = NULL;
+    } else if (!dest) {
+        dest_size = 0;
     }
     for (char value; (value = **src); ++*src) {
         if (value == '"') {


### PR DESCRIPTION
This PR fixes segfault in avs_consume_quotable_token() if 
`dest_size > 0 and dest == NULL`

